### PR TITLE
Fix the Function.prototype object's length proprety

### DIFF
--- a/src/runtime/GlobalObjectBuiltinFunction.cpp
+++ b/src/runtime/GlobalObjectBuiltinFunction.cpp
@@ -234,7 +234,7 @@ static Value builtinFunctionHasInstanceOf(ExecutionState& state, Value thisValue
 
 void GlobalObject::installFunction(ExecutionState& state)
 {
-    FunctionObject* emptyFunction = new FunctionObject(state, new CodeBlock(state.context(), NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionEmptyFunction, 1, nullptr, 0)),
+    FunctionObject* emptyFunction = new FunctionObject(state, new CodeBlock(state.context(), NativeFunctionInfo(state.context()->staticStrings().Function, builtinFunctionEmptyFunction, 0, nullptr, 0)),
                                                        FunctionObject::__ForGlobalBuiltin__);
 
     g_functionObjectTag = *((size_t*)emptyFunction);


### PR DESCRIPTION
According to https://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-function-prototype-object the Function.prototype object's length property should always be 0.
This issue was found by running jerryscript-project/jerryscript#642.

Co-authored-by: Robert Fancsik <frobert@inf.u-szeged.hu>
Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu