### PR TITLE
Minimize APT dependencies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,20 @@ language: cpp
 compiler:
   - gcc
 
-before_install: sudo apt-get install -y autoconf automake libtool libc++-dev libicu-dev gcc-multilib g++-multilib
+before_install:
+  - sudo apt-get install -y autoconf automake libtool
 
 matrix:
   include:
     - name: "check"
-      install: sudo apt-get install -y clang-format-3.8
+      before_install: # skip installation of common build dependencies (not needed for checks)
+        - sudo apt-get install -y clang-format-3.8
       script:
         - python tools/check_tidy.py
 
     - name: "x64.release"
+      install:
+        - sudo apt-get install -y libicu-dev
       script:
         - cmake -H. -Bout/linux/x64/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin
         - make -s -Cout/linux/x64/release -j2
@@ -27,6 +31,8 @@ matrix:
         - make -s -Cout/linux/x64/release run-jsc-stress-x64
 
     - name: "x64.debug"
+      install:
+        - sudo apt-get install -y libicu-dev
       script:
         - cmake -H. -Bout/linux/x64/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin
         - make -s -Cout/linux/x64/debug -j2
@@ -37,7 +43,9 @@ matrix:
         - make -s -Cout/linux/x64/debug run-internal-test
 
     - name: "x86.release"
-      install: "sudo apt-get install -y libicu-dev:i386"
+      install:
+        - sudo apt-get install -y gcc-multilib g++-multilib
+        - "sudo apt-get install -y libicu-dev:i386"
       script:
         - cmake -H. -Bout/linux/x86/release -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin
         - make -s -Cout/linux/x86/release -j2
@@ -52,7 +60,9 @@ matrix:
         - make -s -Cout/linux/x86/release run-jsc-stress-x86
 
     - name: "x86.debug"
-      install: "sudo apt-get install -y libicu-dev:i386"
+      install:
+        - sudo apt-get install -y gcc-multilib g++-multilib
+        - "sudo apt-get install -y libicu-dev:i386"
       script:
         - cmake -H. -Bout/linux/x86/debug -DESCARGOT_HOST=linux -DESCARGOT_ARCH=x86 -DESCARGOT_MODE=debug -DESCARGOT_OUTPUT=bin
         - make -s -Cout/linux/x86/debug -j2
@@ -64,6 +74,7 @@ matrix:
 
     - name: "x64.release (-DVENDORTEST=1)"
       install:
+        - sudo apt-get install -y libicu-dev
         - sudo apt-get install -y npm
         - npm install
       script:
@@ -75,6 +86,7 @@ matrix:
 
     - name: "x86.release (-DVENDORTEST=1)"
       install:
+        - sudo apt-get install -y gcc-multilib g++-multilib
         - "sudo apt-get install -y libicu-dev:i386"
         - sudo apt-get install -y npm
         - npm install
@@ -92,7 +104,10 @@ matrix:
       cache:
         directories:
           - '$HOME/.sonar/cache'
-      script: ./tools/check_sonarqube.sh
+      install:
+        - sudo apt-get install -y libicu-dev
+      script:
+        - ./tools/check_sonarqube.sh
 
   allow_failures:
     - name: "SonarQube"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=pando-project_escargot&metric=alert_status)](https://sonarcloud.io/dashboard?id=pando-project_escargot)
 
 ## Prerequisites
+
+General build prerequisites:
+```sh
+sudo apt-get install autoconf automake libtool libicu-dev
 ```
-apt-get install autoconf automake libtool libc++-dev libicu-dev gcc-multilib g++-multilib
+
+Prerequisites for x86-64-to-x86 compilation:
+```sh
+sudo apt-get install gcc-multilib g++-multilib
+sudo apt-get install libicu-dev:i386
 ```
 
 ## Build Escargot
@@ -43,7 +51,7 @@ git submodule update --init
 
 Prerequisite for SpiderMonkey
 ```sh
-sudo apt-get install -y npm
+sudo apt-get install npm
 npm install
 ```
 


### PR DESCRIPTION
Only install those packages, which are actually needed. This reduces
job startup/execution time (a bit).

Also update README to highlight which dependencies are mandatory and
which are optional.

Note: the libc++-dev dependency has been removed from Travis CI
config and README alike as it turned out not to be needed by any of
the builds.

Signed-off-by: Akos Kiss <akiss@inf.u-szeged.hu>