### PR TITLE
Don't hardcode version into Sonar properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,4 @@
 sonar.projectKey=pando-project_escargot
 sonar.projectName=escargot
-sonar.projectVersion=1.0
 sonar.sources=src
 sonar.cfamily.build-wrapper-output=bw_output

--- a/tools/check_sonarqube.sh
+++ b/tools/check_sonarqube.sh
@@ -20,7 +20,7 @@ if [[ "${TRAVIS_REPO_SLUG}" == "pando-project/escargot"
 then
   git fetch --unshallow
   build-wrapper-linux-x86-64 --out-dir bw_output tools/trigger_build.sh
-  sonar-scanner
+  sonar-scanner -Dsonar.projectVersion="${TRAVIS_COMMIT}"
 else
   echo "Skip: The pull request from ${TRAVIS_PULL_REQUEST_SLUG} is an \
   external one. It's not supported yet in Travis-CI"


### PR DESCRIPTION
Let git hash be the version property so that analysis results can
be mapped to code revisions. (Currenly, SonarCloud shows timestamps
only, which are not really natural identifiers for a git project.)

Signed-off-by: Akos Kiss <akiss@inf.u-szeged.hu>