### PR TITLE
Remove unnecessary assertion in the ArrayObject's setArrayLength function

### DIFF
--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -266,8 +266,6 @@ void ArrayObject::convertIntoNonFastMode(ExecutionState& state)
 
 bool ArrayObject::setArrayLength(ExecutionState& state, const uint64_t& newLength)
 {
-    ASSERT(isExtensible() || newLength <= getArrayLength(state));
-
     if (UNLIKELY(isFastModeArray() && (newLength > ESCARGOT_ARRAY_NON_FASTMODE_MIN_SIZE))) {
         uint32_t orgLength = getArrayLength(state);
         if (newLength > orgLength) {


### PR DESCRIPTION
Fixes #33

There's no need to put an assertion there because:
 - The ArrayObject's length can be changed even when it's not extensible, it just fills the Array with empty values.
 - Modifying the length of an ArrayObject should not throw an error, the only time it should do is when an element is pushed to a non-extensible ArrayObject.

Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu