### PR TITLE
Handle TypedArrays as regular objects instead of array objects in builtinJSONStringify

### DIFF
--- a/src/runtime/GlobalObjectBuiltinJSON.cpp
+++ b/src/runtime/GlobalObjectBuiltinJSON.cpp
@@ -418,7 +418,7 @@ static Value builtinJSONStringify(ExecutionState& state, Value thisValue, size_t
         }
         if (value.isObject()) {
             if (!value.isFunction()) {
-                if (value.asObject()->isArrayObject() || value.asObject()->isTypedArrayObject()) {
+                if (value.asObject()->isArrayObject()) {
                     return JA(value.asObject()->asArrayObject());
                 } else {
                     return JO(value.asObject());


### PR DESCRIPTION
…ltinJSONStringify

Fixes #31

Signed-off-by: Peter Marki marpeter@inf.u-szeged.hu