### PR TITLE
Make tests run on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,41 @@ matrix:
       script:
         - python tools/check_tidy.py
 
+    - name: "darwin.x64.release"
+      os: osx
+      before_install: # override installation of common linux build dependencies (invalid for darwin)
+        - for PKG in autoconf automake cmake icu4c libtool ninja pkg-config; do brew list $PKG &>/dev/null || brew install $PKG; done
+      env:
+        - PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+      script:
+        - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -GNinja
+        - ninja -Cout/darwin/x64/release
+        - cp ./out/darwin/x64/release/escargot ./escargot
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 jetstream-only-simple
+        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js test262 internal octane jsc-stress
+        # FIXME: chakracore fails on darwin
+        # ChakraCore's test runner uses `readlink -f` to determine the test root directory.
+        # However, `readlink` has no `-f` option on macOS.
+
+    - name: "darwin.x64.release (-DVENDORTEST=1)"
+      os: osx
+      before_install: # override installation of common linux build dependencies (invalid for darwin)
+        - for PKG in autoconf automake cmake icu4c libtool ninja node pkg-config; do brew list $PKG &>/dev/null || brew install $PKG; done
+        - npm install
+      env:
+        - PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+      script:
+        - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/darwin/x64/release
+        - cp ./out/darwin/x64/release/escargot ./escargot
+        - tools/run-tests.py --arch=x86_64 v8
+        # FIXME: spidermonkey fails on darwin
+        # SpiderMonkey's ecma/String/15.5.4.12-3.js tests String.prototype.toUpperCase(),
+        # which relies on ICU. Recent ICU versions (installed on macOS) support Unicode 11.0,
+        # which returns upper case letters from the Gregorian Extended block (0x1C90-0x1CBF)
+        # for Gregorian letters (0x10D0-0x10FF). Unfortunately, the test case expects
+        # Unicode 1.0 compatible(?) behaviour, i.e., to return letters unmodified.
+
     - name: "linux.x64.release"
       install:
         - sudo apt-get install -y libicu-dev
@@ -76,41 +111,6 @@ matrix:
         - ninja -Cout/linux/x86/release
         - cp ./out/linux/x86/release/escargot ./escargot
         - tools/run-tests.py --arch=x86 v8 spidermonkey
-
-    - name: "darwin.x64.release"
-      os: osx
-      before_install: # override installation of common linux build dependencies (invalid for darwin)
-        - for PKG in autoconf automake cmake icu4c libtool ninja pkg-config; do brew list $PKG &>/dev/null || brew install $PKG; done
-      env:
-        - PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
-      script:
-        - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -GNinja
-        - ninja -Cout/darwin/x64/release
-        - cp ./out/darwin/x64/release/escargot ./escargot
-        - travis_wait 30 tools/run-tests.py --arch=x86_64 jetstream-only-simple
-        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js test262 internal octane jsc-stress
-        # FIXME: chakracore fails on darwin
-        # ChakraCore's test runner uses `readlink -f` to determine the test root directory.
-        # However, `readlink` has no `-f` option on macOS.
-
-    - name: "darwin.x64.release (-DVENDORTEST=1)"
-      os: osx
-      before_install: # override installation of common linux build dependencies (invalid for darwin)
-        - for PKG in autoconf automake cmake icu4c libtool ninja node pkg-config; do brew list $PKG &>/dev/null || brew install $PKG; done
-        - npm install
-      env:
-        - PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
-      script:
-        - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
-        - ninja -Cout/darwin/x64/release
-        - cp ./out/darwin/x64/release/escargot ./escargot
-        - tools/run-tests.py --arch=x86_64 v8
-        # FIXME: spidermonkey fails on darwin
-        # SpiderMonkey's ecma/String/15.5.4.12-3.js tests String.prototype.toUpperCase(),
-        # which relies on ICU. Recent ICU versions (installed on macOS) support Unicode 11.0,
-        # which returns upper case letters from the Gregorian Extended block (0x1C90-0x1CBF)
-        # for Gregorian letters (0x10D0-0x10FF). Unfortunately, the test case expects
-        # Unicode 1.0 compatible(?) behaviour, i.e., to return letters unmodified.
 
     - name: "SonarQube"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,31 @@ matrix:
       script:
         - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -GNinja
         - ninja -Cout/darwin/x64/release
+        - cp ./out/darwin/x64/release/escargot ./escargot
+        - travis_wait 30 tools/run-tests.py --arch=x86_64 jetstream-only-simple
+        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js test262 internal octane jsc-stress
+        # FIXME: chakracore fails on darwin
+        # ChakraCore's test runner uses `readlink -f` to determine the test root directory.
+        # However, `readlink` has no `-f` option on macOS.
+
+    - name: "darwin.x64.release (-DVENDORTEST=1)"
+      os: osx
+      before_install: # override installation of common linux build dependencies (invalid for darwin)
+        - for PKG in autoconf automake cmake icu4c libtool ninja node pkg-config; do brew list $PKG &>/dev/null || brew install $PKG; done
+        - npm install
+      env:
+        - PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+      script:
+        - cmake -H. -Bout/darwin/x64/release -DESCARGOT_HOST=darwin -DESCARGOT_ARCH=x64 -DESCARGOT_MODE=release -DESCARGOT_OUTPUT=bin -DVENDORTEST=1 -GNinja
+        - ninja -Cout/darwin/x64/release
+        - cp ./out/darwin/x64/release/escargot ./escargot
+        - tools/run-tests.py --arch=x86_64 v8
+        # FIXME: spidermonkey fails on darwin
+        # SpiderMonkey's ecma/String/15.5.4.12-3.js tests String.prototype.toUpperCase(),
+        # which relies on ICU. Recent ICU versions (installed on macOS) support Unicode 11.0,
+        # which returns upper case letters from the Gregorian Extended block (0x1C90-0x1CBF)
+        # for Gregorian letters (0x10D0-0x10FF). Unfortunately, the test case expects
+        # Unicode 1.0 compatible(?) behaviour, i.e., to return letters unmodified.
 
     - name: "SonarQube"
       addons:

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -286,6 +286,7 @@ def run_v8(engine, arch):
                   '--report',
                   '-p', 'verbose',
                   '--no-sorting',
+                  '--no-network',
                   'mjsunit'],
                  stdout=PIPE,
                  checkresult=False)
@@ -297,11 +298,8 @@ def run_v8(engine, arch):
     # observed exit code is that of the last element of the pipe, which is
     # tee in that case (which is always 0).
 
-    with open(join(PROJECT_SOURCE_DIR, 'test', 'vendortest', 'driver', 'v8.%s.mjsunit.gen.txt' % arch), 'w') as msunit_gen_txt:
-        msunit_gen_txt.write(stdout)
-    run(['diff',
-         join(PROJECT_SOURCE_DIR, 'test', 'vendortest', 'driver', 'v8.%s.mjsunit.orig.txt' % arch),
-         join(PROJECT_SOURCE_DIR, 'test', 'vendortest', 'driver', 'v8.%s.mjsunit.gen.txt' % arch)])
+    if '=== All tests succeeded' not in stdout:
+        raise Exception('Not all tests succeeded')
 
 
 def main():

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -155,7 +155,14 @@ def run_spidermonkey(engine, arch):
     SPIDERMONKEY_OVERRIDE_DIR = join(PROJECT_SOURCE_DIR, 'test', 'vendortest', 'driver')
     SPIDERMONKEY_DIR = join(PROJECT_SOURCE_DIR, 'test', 'vendortest', 'SpiderMonkey')
 
-    run(['nodejs', join(PROJECT_SOURCE_DIR, 'node_modules', '.bin', 'babel'), join(SPIDERMONKEY_DIR, 'ecma_6', 'Promise'), '--out-dir', join(SPIDERMONKEY_DIR, 'ecma_6', 'Promise')])
+    for nodejs in ['nodejs', 'node']:
+        try:
+            run([nodejs, '-v'])
+            break
+        except Exception:
+            continue
+
+    run([nodejs, join(PROJECT_SOURCE_DIR, 'node_modules', '.bin', 'babel'), join(SPIDERMONKEY_DIR, 'ecma_6', 'Promise'), '--out-dir', join(SPIDERMONKEY_DIR, 'ecma_6', 'Promise')])
     copy(join(SPIDERMONKEY_OVERRIDE_DIR, 'spidermonkey.shell.js'), join(SPIDERMONKEY_DIR, 'shell.js'))
     copy(join(SPIDERMONKEY_OVERRIDE_DIR, 'spidermonkey.js1_8_1.jit.shell.js'), join(SPIDERMONKEY_DIR, 'js1_8_1', 'jit', 'shell.js'))
     copy(join(SPIDERMONKEY_OVERRIDE_DIR, 'spidermonkey.ecma_6.shell.js'), join(SPIDERMONKEY_DIR, 'ecma_6', 'shell.js'))


### PR DESCRIPTION
To prevent regressing on macOS, this PR makes (most of) the test suites runnable on macOS:
- It improves V8 and SpiderMonkey test runners to work on multiple platforms.
- It extends darwin jobs on Travis CI with test executions, just like they are done for Linux targets.

Note: For now, chakracore and spidermonkey tests are disabled for macOS as they would need further fixes outside this repository.

Follow-up to #24
