### PR TITLE
Update missing builtin functions of String

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -168,6 +168,7 @@
 #include <unicode/locid.h>
 #include <unicode/uchar.h>
 #include <unicode/datefmt.h>
+#include <unicode/unorm.h> // for normalize builtin function of String
 #include <unicode/ucol.h> // for Intl
 #include <unicode/urename.h> // for Intl
 #include <unicode/unumsys.h> // for Intl

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -255,6 +255,7 @@ namespace Escargot {
     F(map)                        \
     F(match)                      \
     F(now)                        \
+    F(normalize)                  \
     F(parseFloat)                 \
     F(parseInt)                   \
     F(preventExtensions)          \
@@ -263,6 +264,7 @@ namespace Escargot {
     F(append)                     \
     F(reduce)                     \
     F(reduceRight)                \
+    F(repeat)                     \
     F(replace)                    \
     F(reverse)                    \
     F(run)                        \


### PR DESCRIPTION
* Implement repeat and normalize
* normalize function exploits unicode normalization forms

**NOTE**
[unicode normalization](http://www.unicode.org/reports/tr15/tr15-29.html)

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>