### PR TITLE
Fix bytecode generation for var statements in for-in statements

### DIFF
--- a/src/parser/ast/VariableDeclarationNode.h
+++ b/src/parser/ast/VariableDeclarationNode.h
@@ -51,11 +51,6 @@ public:
     virtual void generateStoreByteCode(ByteCodeBlock* codeBlock, ByteCodeGenerateContext* context, ByteCodeRegisterIndex src, bool needToReferenceSelf)
     {
         ASSERT(m_declarations.size() == 1);
-        if (m_declarations[0]->init()) {
-            src = m_declarations[0]->init()->getRegister(codeBlock, context);
-            m_declarations[0]->init()->generateExpressionByteCode(codeBlock, context, src);
-            context->giveUpRegister();
-        }
         m_declarations[0]->id()->generateStoreByteCode(codeBlock, context, src, false);
     }
 

--- a/test/regression-tests/issue-29.js
+++ b/test/regression-tests/issue-29.js
@@ -1,0 +1,33 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var obj = {a: 1, b: 2, c: 3};
+var keys = Object.keys(obj);
+var cnt = 0;
+var foo_called = 0;
+
+function foo() {
+    foo_called++;
+    return 5;
+}
+
+for (var i = foo() in obj) {
+    assert(i === keys[cnt]);
+    cnt++;
+}
+
+assert(foo_called === 1);
+
+for ( var id_0 = { toString : function ( ) {} } in Array.toString ) { }


### PR DESCRIPTION
Fixes #29

Signed-off-by: Peter Marki marpeter@inf.u-szeged.hu