### PR TITLE
Fix an issue with Object Property Descriptors

### DIFF
--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -523,11 +523,10 @@ bool Object::defineOwnProperty(ExecutionState& state, const ObjectPropertyName& 
                 newDesc = ObjectPropertyDescriptor(desc.getterSetter(), (ObjectPropertyDescriptor::PresentAttribute)f);
             } else {
                 // Else,
-                // Convert the property named P of object O from a data property to an accessor property.
-                // Preserve the existing values of the converted property’s [[Configurable]] and [[Enumerable]] attributes
-                // and set the rest of the property’s attributes to their default values.
-                newDesc = desc.isValuePresent() ? ObjectPropertyDescriptor(desc.value(), (ObjectPropertyDescriptor::PresentAttribute)f)
-                                                : ObjectPropertyDescriptor((ObjectPropertyDescriptor::PresentAttribute)f);
+                // Convert the property named P of object O from an accessor property to a data property.
+                // Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes
+                // and set the rest of the property's attributes to their default values.
+                newDesc = ObjectPropertyDescriptor(desc.isValuePresent() ? desc.value() : Value(), (ObjectPropertyDescriptor::PresentAttribute)f);
             }
         }
         // Else, if IsDataDescriptor(current) and IsDataDescriptor(Desc) are both true, then


### PR DESCRIPTION
Pass an undefined value as Property Descriptor's `value` property if the previous descriptor's value was not present.

Co-authored-by: Robert Fancsik <frobert@inf.u-szeged.hu>
Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu