### PR TITLE
Fix the function declarations in catch statement

### DIFF
--- a/src/parser/ast/TryStatementNode.h
+++ b/src/parser/ast/TryStatementNode.h
@@ -71,8 +71,9 @@ public:
                     }
                 }
                 codeBlock->pushCode(CreateFunction(ByteCodeLOC(m_loc.index), r, blk), context, this);
-                IdentifierNode node(blk->functionName());
-                node.generateStoreByteCode(codeBlock, context, r, false);
+
+                RefPtr<IdentifierNode> node = adoptRef(new IdentifierNode(blk->functionName()));
+                node->generateStoreByteCode(codeBlock, context, r, false);
                 context->giveUpRegister();
             }
 

--- a/test/regression-tests/issue-27.js
+++ b/test/regression-tests/issue-27.js
@@ -1,0 +1,19 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+try {
+} catch ( o ) {
+    function fun( ) { } (1);
+}


### PR DESCRIPTION
Use dynamic allocation for IdentifierNode to prevent early destructor call.

Fixes #27