### PR TITLE
Call generateStatementByteCode only for statement nodes

### DIFF
--- a/src/parser/ast/ForStatementNode.h
+++ b/src/parser/ast/ForStatementNode.h
@@ -48,7 +48,7 @@ public:
 
         newContext.getRegister(); // ExeuctionResult of m_body should not be overwritten by m_test
 
-        if (m_init) {
+        if (m_init && m_init->type() != ASTNodeType::RegExpLiteral) {
             m_init->generateStatementByteCode(codeBlock, &newContext);
         }
 

--- a/test/regression-tests/issue-35.js
+++ b/test/regression-tests/issue-35.js
@@ -1,0 +1,18 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+for ( /৉/ ; ; ) {
+    break;
+}


### PR DESCRIPTION
Fixes #35
