### PR TITLE
Reduce code smell - explicit

### DIFF
--- a/src/heap/CustomAllocator.h
+++ b/src/heap/CustomAllocator.h
@@ -87,7 +87,7 @@ public:
 #if !(GC_NO_MEMBER_TEMPLATES || 0 < _MSC_VER && _MSC_VER <= 1200)
     // MSVC++ 6.0 do not support member templates
     template <class GC_Tp1>
-    CustomAllocator(const CustomAllocator<GC_Tp1>&) noexcept {}
+    explicit CustomAllocator(const CustomAllocator<GC_Tp1>&) noexcept {}
 #endif
     ~CustomAllocator() noexcept
     {

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -336,7 +336,7 @@ public:
 
 class DeclareFunctionDeclarations : public ByteCode {
 public:
-    DeclareFunctionDeclarations(InterpretedCodeBlock* cb)
+    explicit DeclareFunctionDeclarations(InterpretedCodeBlock* cb)
         : ByteCode(Opcode::DeclareFunctionDeclarationsOpcode, ByteCodeLOC(SIZE_MAX))
         , m_codeBlock(cb)
     {
@@ -1247,7 +1247,7 @@ public:
 
 class ReturnFunction : public ByteCode {
 public:
-    ReturnFunction(const ByteCodeLOC& loc)
+    explicit ReturnFunction(const ByteCodeLOC& loc)
         : ByteCode(Opcode::ReturnFunctionOpcode, loc)
     {
     }
@@ -1295,7 +1295,7 @@ public:
 
 class TryOperation : public ByteCode {
 public:
-    TryOperation(const ByteCodeLOC& loc)
+    explicit TryOperation(const ByteCodeLOC& loc)
         : ByteCode(Opcode::TryOperationOpcode, loc)
     {
         m_hasCatch = false;
@@ -1316,7 +1316,7 @@ public:
 
 class TryCatchWithBodyEnd : public ByteCode {
 public:
-    TryCatchWithBodyEnd(const ByteCodeLOC& loc)
+    explicit TryCatchWithBodyEnd(const ByteCodeLOC& loc)
         : ByteCode(Opcode::TryCatchWithBodyEndOpcode, loc)
     {
     }
@@ -1331,7 +1331,7 @@ public:
 
 class FinallyEnd : public ByteCode {
 public:
-    FinallyEnd(const ByteCodeLOC& loc)
+    explicit FinallyEnd(const ByteCodeLOC& loc)
         : ByteCode(Opcode::FinallyEndOpcode, loc)
     {
         m_tryDupCount = 0;
@@ -1404,7 +1404,7 @@ struct EnumerateObjectData : public PointerValue {
 
 class EnumerateObject : public ByteCode {
 public:
-    EnumerateObject(const ByteCodeLOC& loc)
+    explicit EnumerateObject(const ByteCodeLOC& loc)
         : ByteCode(Opcode::EnumerateObjectOpcode, loc)
     {
         m_objectRegisterIndex = m_dataRegisterIndex = std::numeric_limits<ByteCodeRegisterIndex>::max();
@@ -1422,7 +1422,7 @@ public:
 
 class EnumerateObjectKey : public ByteCode {
 public:
-    EnumerateObjectKey(const ByteCodeLOC& loc)
+    explicit EnumerateObjectKey(const ByteCodeLOC& loc)
         : ByteCode(Opcode::EnumerateObjectKeyOpcode, loc)
     {
         m_dataRegisterIndex = m_registerIndex = std::numeric_limits<ByteCodeRegisterIndex>::max();
@@ -1440,7 +1440,7 @@ public:
 
 class CheckIfKeyIsLast : public ByteCode {
 public:
-    CheckIfKeyIsLast(const ByteCodeLOC& loc)
+    explicit CheckIfKeyIsLast(const ByteCodeLOC& loc)
         : ByteCode(Opcode::CheckIfKeyIsLastOpcode, loc)
     {
         m_forInEndPosition = SIZE_MAX;
@@ -1540,7 +1540,7 @@ public:
 
 class End : public ByteCode {
 public:
-    End(const ByteCodeLOC& loc)
+    explicit End(const ByteCodeLOC& loc)
         : ByteCode(Opcode::EndOpcode, loc)
     {
     }
@@ -1576,7 +1576,7 @@ class ByteCodeBlock : public gc {
     }
 
 public:
-    ByteCodeBlock(InterpretedCodeBlock* codeBlock)
+    explicit ByteCodeBlock(InterpretedCodeBlock* codeBlock)
     {
         m_requiredRegisterFileSizeInValueSize = 2;
         m_codeBlock = codeBlock;

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -1820,7 +1820,7 @@ NEVER_INLINE Value ByteCodeInterpreter::getGlobalObjectSlowCase(ExecutionState& 
 
 class VirtualIdDisabler {
 public:
-    VirtualIdDisabler(Context* c)
+    explicit VirtualIdDisabler(Context* c)
     {
         ctx = c;
         fn = c->virtualIdentifierCallback();

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -36,7 +36,7 @@ typedef Vector<void*, GCUtil::gc_malloc_ignore_off_page_allocator<void*>, 150> L
 
 class ScriptParser : public gc {
 public:
-    ScriptParser(Context* c);
+    explicit ScriptParser(Context* c);
 
     struct ScriptParseError : public gc {
         String* name;

--- a/src/parser/ast/ArrowFunctionExpressionNode.h
+++ b/src/parser/ast/ArrowFunctionExpressionNode.h
@@ -31,7 +31,7 @@ public:
     {
     }
 
-    ArrowParameterPlaceHolderNode(ExpressionNodeVector&& params)
+    explicit ArrowParameterPlaceHolderNode(ExpressionNodeVector&& params)
         : Node()
         , m_params(std::move(params))
     {

--- a/src/parser/ast/BlockStatementNode.h
+++ b/src/parser/ast/BlockStatementNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class BlockStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    BlockStatementNode(StatementContainer* body)
+    explicit BlockStatementNode(StatementContainer* body)
         : StatementNode()
     {
         m_container = body;

--- a/src/parser/ast/BreakLabelStatementNode.h
+++ b/src/parser/ast/BreakLabelStatementNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class BreakLabelStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    BreakLabelStatementNode(String* label)
+    explicit BreakLabelStatementNode(String* label)
         : StatementNode()
     {
         m_label = label;

--- a/src/parser/ast/ContinueLabelStatementNode.h
+++ b/src/parser/ast/ContinueLabelStatementNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class ContinueLabelStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ContinueLabelStatementNode(String* label)
+    explicit ContinueLabelStatementNode(String* label)
         : StatementNode()
     {
         m_label = label;

--- a/src/parser/ast/ExpressionStatementNode.h
+++ b/src/parser/ast/ExpressionStatementNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class ExpressionStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ExpressionStatementNode(Node* expression)
+    explicit ExpressionStatementNode(Node* expression)
         : StatementNode()
     {
         m_expression = expression;

--- a/src/parser/ast/IdentifierNode.h
+++ b/src/parser/ast/IdentifierNode.h
@@ -31,7 +31,7 @@ namespace Escargot {
 class IdentifierNode : public Node {
 public:
     friend class ScriptParser;
-    IdentifierNode(const AtomicString& name)
+    explicit IdentifierNode(const AtomicString& name)
         : Node()
     {
         m_name = name;

--- a/src/parser/ast/LiteralNode.h
+++ b/src/parser/ast/LiteralNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 // interface Literal <: Node, Expression {
 class LiteralNode : public ExpressionNode {
 public:
-    LiteralNode(Value value)
+    explicit LiteralNode(Value value)
         : ExpressionNode()
     {
         m_value = value;

--- a/src/parser/ast/Node.h
+++ b/src/parser/ast/Node.h
@@ -136,7 +136,7 @@ enum ASTNodeType {
 
 struct NodeLOC {
     size_t index;
-    NodeLOC(size_t index)
+    explicit NodeLOC(size_t index)
     {
         this->index = index;
     }
@@ -398,7 +398,7 @@ struct ASTScopeContext : public gc {
         }
     }
 
-    ASTScopeContext(bool isStrict = false)
+    explicit ASTScopeContext(bool isStrict = false)
         : m_locStart(SIZE_MAX, SIZE_MAX, SIZE_MAX)
 #ifndef NDEBUG
         , m_locEnd(SIZE_MAX, SIZE_MAX, SIZE_MAX)

--- a/src/parser/ast/ObjectExpressionNode.h
+++ b/src/parser/ast/ObjectExpressionNode.h
@@ -29,7 +29,7 @@ namespace Escargot {
 class ObjectExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    ObjectExpressionNode(PropertiesNodeVector&& properties)
+    explicit ObjectExpressionNode(PropertiesNodeVector&& properties)
         : ExpressionNode()
     {
         m_properties = properties;

--- a/src/parser/ast/RestElementNode.h
+++ b/src/parser/ast/RestElementNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 
 class RestElementNode : public Node {
 public:
-    RestElementNode(IdentifierNode* argument)
+    explicit RestElementNode(IdentifierNode* argument)
         : Node()
     {
         m_argument = argument;

--- a/src/parser/ast/ReturnStatmentNode.h
+++ b/src/parser/ast/ReturnStatmentNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class ReturnStatmentNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ReturnStatmentNode(Node* argument)
+    explicit ReturnStatmentNode(Node* argument)
         : StatementNode()
     {
         m_argument = argument;

--- a/src/parser/ast/SequenceExpressionNode.h
+++ b/src/parser/ast/SequenceExpressionNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class SequenceExpressionNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    SequenceExpressionNode(ExpressionNodeVector&& expressions)
+    explicit SequenceExpressionNode(ExpressionNodeVector&& expressions)
         : ExpressionNode()
     {
         m_expressions = expressions;

--- a/src/parser/ast/SpreadElementNode.h
+++ b/src/parser/ast/SpreadElementNode.h
@@ -26,7 +26,7 @@ namespace Escargot {
 
 class SpreadElementNode : public Node {
 public:
-    SpreadElementNode(Node* arg)
+    explicit SpreadElementNode(Node* arg)
         : Node()
     {
         m_arg = arg;

--- a/src/parser/ast/ThrowStatementNode.h
+++ b/src/parser/ast/ThrowStatementNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class ThrowStatementNode : public StatementNode {
 public:
     friend class ScriptParser;
-    ThrowStatementNode(Node* argument)
+    explicit ThrowStatementNode(Node* argument)
         : StatementNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UnaryExpressionDeleteNode.h
+++ b/src/parser/ast/UnaryExpressionDeleteNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionDeleteNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionDeleteNode(Node* argument)
+    explicit UnaryExpressionDeleteNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = (ExpressionNode*)argument;

--- a/src/parser/ast/UnaryExpressionLogicalNotNode.h
+++ b/src/parser/ast/UnaryExpressionLogicalNotNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionLogicalNotNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionLogicalNotNode(Node* argument)
+    explicit UnaryExpressionLogicalNotNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UnaryExpressionMinusNode.h
+++ b/src/parser/ast/UnaryExpressionMinusNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionMinusNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionMinusNode(Node* argument)
+    explicit UnaryExpressionMinusNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UnaryExpressionPlusNode.h
+++ b/src/parser/ast/UnaryExpressionPlusNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionPlusNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionPlusNode(Node* argument)
+    explicit UnaryExpressionPlusNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UnaryExpressionTypeOfNode.h
+++ b/src/parser/ast/UnaryExpressionTypeOfNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionTypeOfNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionTypeOfNode(Node* argument)
+    explicit UnaryExpressionTypeOfNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UnaryExpressionVoidNode.h
+++ b/src/parser/ast/UnaryExpressionVoidNode.h
@@ -27,7 +27,7 @@ namespace Escargot {
 class UnaryExpressionVoidNode : public ExpressionNode {
 public:
     friend class ScriptParser;
-    UnaryExpressionVoidNode(Node* argument)
+    explicit UnaryExpressionVoidNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = argument;

--- a/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionDecrementPrefixNode.h
@@ -28,7 +28,7 @@ class UpdateExpressionDecrementPrefixNode : public ExpressionNode {
 public:
     friend class ScriptParser;
 
-    UpdateExpressionDecrementPrefixNode(Node* argument)
+    explicit UpdateExpressionDecrementPrefixNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = (ExpressionNode*)argument;

--- a/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPostfixNode.h
@@ -28,7 +28,7 @@ class UpdateExpressionIncrementPostfixNode : public ExpressionNode {
 public:
     friend class ScriptParser;
 
-    UpdateExpressionIncrementPostfixNode(Node* argument)
+    explicit UpdateExpressionIncrementPostfixNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = (ExpressionNode*)argument;

--- a/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
+++ b/src/parser/ast/UpdateExpressionIncrementPrefixNode.h
@@ -28,7 +28,7 @@ class UpdateExpressionIncrementPrefixNode : public ExpressionNode {
 public:
     friend class ScriptParser;
 
-    UpdateExpressionIncrementPrefixNode(Node* argument)
+    explicit UpdateExpressionIncrementPrefixNode(Node* argument)
         : ExpressionNode()
     {
         m_argument = (ExpressionNode*)argument;

--- a/src/parser/ast/VariableDeclarationNode.h
+++ b/src/parser/ast/VariableDeclarationNode.h
@@ -28,7 +28,7 @@ namespace Escargot {
 class VariableDeclarationNode : public DeclarationNode {
 public:
     friend class ScriptParser;
-    VariableDeclarationNode(VariableDeclaratorVector&& decl)
+    explicit VariableDeclarationNode(VariableDeclaratorVector&& decl)
         : DeclarationNode()
     {
         m_declarations = decl;

--- a/src/parser/esprima_cpp/esprima.h
+++ b/src/parser/esprima_cpp/esprima.h
@@ -70,7 +70,7 @@ struct Error : public gc {
     String* description;
     ErrorObject::Code errorCode;
 
-    Error(String* message)
+    explicit Error(String* message)
     {
         this->name = String::emptyString;
         this->message = message;

--- a/src/runtime/ArrayBufferObject.h
+++ b/src/runtime/ArrayBufferObject.h
@@ -36,7 +36,7 @@ extern ArrayBufferObjectBufferFreeFunction g_arrayBufferObjectBufferFreeFunction
 
 class ArrayBufferObject : public Object {
 public:
-    ArrayBufferObject(ExecutionState& state);
+    explicit ArrayBufferObject(ExecutionState& state);
     // http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2
     virtual const char* internalClassProperty()
     {

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -43,7 +43,7 @@ class ArrayObject : public Object {
     friend int getValidValueInArrayObject(void* ptr, GC_mark_custom_result* arr);
 
 public:
-    ArrayObject(ExecutionState& state);
+    explicit ArrayObject(ExecutionState& state);
     ArrayObject(ExecutionState& state, double size); // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-arraycreate
     virtual bool isArrayObject() const override
     {

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -34,7 +34,7 @@ class AtomicString : public gc {
     friend class PropertyName;
     friend class ASTScopeContextNameInfo;
     friend class AtomicStringRef;
-    inline AtomicString(String* str)
+    inline explicit AtomicString(String* str)
     {
         m_string = str;
     }

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -53,7 +53,7 @@ class Context : public gc {
     friend class ContextRef;
 
 public:
-    Context(VMInstance* instance);
+    explicit Context(VMInstance* instance);
 
     VMInstance* vmInstance()
     {

--- a/src/runtime/DataViewObject.h
+++ b/src/runtime/DataViewObject.h
@@ -31,7 +31,7 @@ namespace Escargot {
 
 class DataViewObject : public ArrayBufferView {
 public:
-    DataViewObject(ExecutionState& state)
+    explicit DataViewObject(ExecutionState& state)
         : ArrayBufferView(state)
     {
     }

--- a/src/runtime/DateObject.h
+++ b/src/runtime/DateObject.h
@@ -49,7 +49,7 @@ static const int64_t const_Date_msPerDay = const_Date_msPerHour * const_Date_hou
 
 class DateObject : public Object {
 public:
-    DateObject(ExecutionState& state);
+    explicit DateObject(ExecutionState& state);
 
     static void initCachedUTC(ExecutionState& state, DateObject* d);
 

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -100,7 +100,7 @@ public:
         {
         }
 
-        GetBindingValueResult(const Value& v)
+        explicit GetBindingValueResult(const Value& v)
             : m_hasBindingValue(true)
             , m_value(v)
         {
@@ -175,7 +175,7 @@ protected:
 
 class ObjectEnvironmentRecord : public EnvironmentRecord {
 public:
-    ObjectEnvironmentRecord(Object* O)
+    explicit ObjectEnvironmentRecord(Object* O)
         : EnvironmentRecord()
         , m_bindingObject(O)
     {
@@ -405,7 +405,7 @@ class FunctionEnvironmentRecord : public DeclarativeEnvironmentRecord {
     friend class ByteCodeInterpreter;
 
 public:
-    ALWAYS_INLINE FunctionEnvironmentRecord(FunctionObject* function)
+    ALWAYS_INLINE explicit FunctionEnvironmentRecord(FunctionObject* function)
         : DeclarativeEnvironmentRecord()
         , m_functionObject(function)
     {
@@ -459,7 +459,7 @@ class FunctionEnvironmentRecordSimple : public FunctionEnvironmentRecord {
     friend class LexicalEnvironment;
 
 public:
-    ALWAYS_INLINE FunctionEnvironmentRecordSimple(FunctionObject* function)
+    ALWAYS_INLINE explicit FunctionEnvironmentRecordSimple(FunctionObject* function)
         : FunctionEnvironmentRecord(function)
     {
     }

--- a/src/runtime/GlobalObject.h
+++ b/src/runtime/GlobalObject.h
@@ -47,7 +47,7 @@ public:
     friend class GlobalEnvironmentRecord;
     friend class IdentifierNode;
 
-    GlobalObject(ExecutionState& state)
+    explicit GlobalObject(ExecutionState& state)
         : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, false)
         , m_context(state.context())
     {

--- a/src/runtime/GlobalRegExpFunctionObject.h
+++ b/src/runtime/GlobalRegExpFunctionObject.h
@@ -49,7 +49,7 @@ class GlobalRegExpFunctionObject : public FunctionObject {
     friend struct GlobalRegExpFunctionObjectBuiltinFunctions;
 
 public:
-    GlobalRegExpFunctionObject(ExecutionState& state);
+    explicit GlobalRegExpFunctionObject(ExecutionState& state);
     virtual bool isGlobalRegExpFunctionObject()
     {
         return true;

--- a/src/runtime/IteratorObject.h
+++ b/src/runtime/IteratorObject.h
@@ -31,7 +31,7 @@ class SetIteratorObject;
 
 class IteratorObject : public Object {
 public:
-    IteratorObject(ExecutionState& state);
+    explicit IteratorObject(ExecutionState& state);
 
     virtual bool isIteratorObject() const
     {

--- a/src/runtime/MapObject.h
+++ b/src/runtime/MapObject.h
@@ -32,7 +32,7 @@ class MapObject : public Object {
 
 public:
     typedef TightVector<std::pair<SmallValue, SmallValue>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<SmallValue, SmallValue>>> MapObjectData;
-    MapObject(ExecutionState& state);
+    explicit MapObject(ExecutionState& state);
 
     virtual bool isMapObject() const override
     {

--- a/src/runtime/NumberObject.cpp
+++ b/src/runtime/NumberObject.cpp
@@ -76,7 +76,7 @@ inline void decomposeDouble(double number, bool& sign, int32_t& exponent, uint64
 // This is used in converting the integer part of a number to a string.
 class BigInteger {
 public:
-    BigInteger(double number)
+    explicit BigInteger(double number)
     {
         m_values.reserve(36);
         ASSERT(std::isfinite(number) && !std::signbit(number));

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -54,7 +54,7 @@ struct ObjectRareData : public PointerValue {
 #ifdef ESCARGOT_ENABLE_PROMISE
     Object* m_internalSlot;
 #endif
-    ObjectRareData(Object* obj);
+    explicit ObjectRareData(Object* obj);
 
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
@@ -531,7 +531,7 @@ class Object : public PointerValue {
     static Object* createBuiltinObjectPrototype(ExecutionState& state);
 
 public:
-    Object(ExecutionState& state);
+    explicit Object(ExecutionState& state);
     static Object* createFunctionPrototypeObject(ExecutionState& state, FunctionObject* function);
 
     virtual bool isObject() const

--- a/src/runtime/ObjectStructure.h
+++ b/src/runtime/ObjectStructure.h
@@ -194,7 +194,7 @@ class ObjectStructureWithFastAccess : public ObjectStructure {
     friend class ObjectStructure;
 
 public:
-    ObjectStructureWithFastAccess(ExecutionState& state)
+    explicit ObjectStructureWithFastAccess(ExecutionState& state)
         : ObjectStructure(state, false)
         , m_propertyNameMap(new (GC) PropertyNameMap())
     {

--- a/src/runtime/ObjectStructurePropertyDescriptor.h
+++ b/src/runtime/ObjectStructurePropertyDescriptor.h
@@ -177,7 +177,7 @@ protected:
             ASSERT(mode < 2);
         }
 
-        ObjectStructurePropertyDescriptorData(ObjectPropertyNativeGetterSetterData* nativeGetterSetterData)
+        explicit ObjectStructurePropertyDescriptorData(ObjectPropertyNativeGetterSetterData* nativeGetterSetterData)
         {
             m_nativeGetterSetterData = nativeGetterSetterData;
         }
@@ -247,7 +247,7 @@ protected:
         }
     }
 
-    ObjectStructurePropertyDescriptor(ObjectPropertyNativeGetterSetterData* nativeGetterSetterData)
+    explicit ObjectStructurePropertyDescriptor(ObjectPropertyNativeGetterSetterData* nativeGetterSetterData)
         : m_descriptorData(nativeGetterSetterData)
     {
     }

--- a/src/runtime/PromiseObject.h
+++ b/src/runtime/PromiseObject.h
@@ -81,7 +81,7 @@ public:
         Rejected
     };
 
-    PromiseObject(ExecutionState& state);
+    explicit PromiseObject(ExecutionState& state);
 
     virtual bool isPromiseObject() const
     {

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -85,7 +85,7 @@ public:
         JSC::Yarr::BytecodePattern* m_bytecodePattern;
     };
 
-    RegExpObject(ExecutionState& state);
+    explicit RegExpObject(ExecutionState& state);
     RegExpObject(ExecutionState& state, String* source, String* option);
 
     void init(ExecutionState& state, String* source, String* option);

--- a/src/runtime/SandBox.h
+++ b/src/runtime/SandBox.h
@@ -30,7 +30,7 @@ class SandBox : public gc {
     friend class ErrorObject;
 
 public:
-    SandBox(Context* s)
+    explicit SandBox(Context* s)
     {
         m_context = s;
         m_context->m_sandBoxStack.pushBack(this);

--- a/src/runtime/SetObject.h
+++ b/src/runtime/SetObject.h
@@ -32,7 +32,7 @@ class SetObject : public Object {
 
 public:
     typedef TightVector<SmallValue, GCUtil::gc_malloc_ignore_off_page_allocator<SmallValue>> SetObjectData;
-    SetObject(ExecutionState& state);
+    explicit SetObject(ExecutionState& state);
 
     virtual bool isSetObject() const override
     {

--- a/src/runtime/SmallValue.h
+++ b/src/runtime/SmallValue.h
@@ -46,7 +46,7 @@ public:
         return true;
     }
 
-    DoubleInSmallValue(double v)
+    explicit DoubleInSmallValue(double v)
         : m_value(v)
     {
     }
@@ -169,7 +169,7 @@ public:
         m_data.payload = from.m_data.payload;
     }
 
-    SmallValue(const uint32_t& from)
+    explicit SmallValue(const uint32_t& from)
     {
         if (LIKELY(SmallValueImpl::PlatformSmiTagging::IsValidSmi(from))) {
             m_data.payload = SmallValueImpl::PlatformSmiTagging::IntToSmi(from);
@@ -183,7 +183,7 @@ public:
         fromValueForCtor(from);
     }
 
-    SmallValue(PointerValue* v)
+    explicit SmallValue(PointerValue* v)
     {
         if (v) {
             m_data.payload = (intptr_t)v;
@@ -371,7 +371,7 @@ protected:
         ASSERT(m_data.payload);
     }
 
-    SmallValue(SmallValueData v)
+    explicit SmallValue(SmallValueData v)
         : m_data(v)
     {
     }
@@ -388,7 +388,7 @@ namespace std {
 
 template <>
 struct is_fundamental<Escargot::SmallValue> {
-    operator bool() const
+    explicit operator bool() const
     {
         return true;
     }

--- a/src/runtime/SmallValueData.h
+++ b/src/runtime/SmallValueData.h
@@ -28,7 +28,7 @@ union SmallValueData {
     {
     }
 
-    SmallValueData(void* ptr)
+    explicit SmallValueData(void* ptr)
     {
         payload = (intptr_t)ptr;
     }

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -357,14 +357,14 @@ class ASCIIString : public String {
     friend class String;
 
 public:
-    ASCIIString(ASCIIStringData&& src)
+    explicit ASCIIString(ASCIIStringData&& src)
         : String()
     {
         ASCIIStringData stringData = std::move(src);
         initBufferAccessData(stringData);
     }
 
-    ASCIIString(const char* str)
+    explicit ASCIIString(const char* str)
         : String()
     {
         ASCIIStringData stringData;
@@ -436,14 +436,14 @@ class Latin1String : public String {
     friend class Latin1;
 
 public:
-    Latin1String(Latin1StringData&& src)
+    explicit Latin1String(Latin1StringData&& src)
         : String()
     {
         Latin1StringData data = std::move(src);
         initBufferAccessData(data);
     }
 
-    Latin1String(const char* str)
+    explicit Latin1String(const char* str)
         : String()
     {
         Latin1StringData data;
@@ -524,7 +524,7 @@ class UTF16String : public String {
     friend class String;
 
 public:
-    UTF16String(UTF16StringData&& src)
+    explicit UTF16String(UTF16StringData&& src)
         : String()
     {
         UTF16StringData data = std::move(src);
@@ -539,7 +539,7 @@ public:
         initBufferAccessData(data);
     }
 #ifdef ENABLE_ICU
-    UTF16String(icu::UnicodeString& src)
+    explicit UTF16String(icu::UnicodeString& src)
         : String()
     {
         UTF16StringData str;

--- a/src/runtime/StringView.h
+++ b/src/runtime/StringView.h
@@ -176,7 +176,7 @@ protected:
 
 class SourceStringView : public String {
 public:
-    ALWAYS_INLINE SourceStringView(const StringView& str)
+    ALWAYS_INLINE explicit SourceStringView(const StringView& str)
     {
         m_bufferAccessData = str.bufferAccessData();
     }

--- a/src/runtime/Symbol.h
+++ b/src/runtime/Symbol.h
@@ -28,7 +28,7 @@ extern size_t g_symbolTag;
 
 class Symbol : public PointerValue {
 public:
-    Symbol(String* desc = String::emptyString)
+    explicit Symbol(String* desc = String::emptyString)
     {
         m_tag = POINTER_VALUE_STRING_SYMBOL_TAG_IN_DATA;
         m_description = desc;

--- a/src/runtime/TypedArrayObject.h
+++ b/src/runtime/TypedArrayObject.h
@@ -43,7 +43,7 @@ enum TypedArrayType : unsigned {
 
 class ArrayBufferView : public Object {
 public:
-    ArrayBufferView(ExecutionState& state)
+    explicit ArrayBufferView(ExecutionState& state)
         : Object(state, ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER, true)
     {
         m_rawBuffer = nullptr;
@@ -228,7 +228,7 @@ class TypedArrayObject : public ArrayBufferView {
     void typedArrayObjectPrototypeFiller(ExecutionState& state);
 
 public:
-    TypedArrayObject(ExecutionState& state)
+    explicit TypedArrayObject(ExecutionState& state)
         : ArrayBufferView(state)
     {
         typedArrayObjectPrototypeFiller(state);
@@ -333,7 +333,7 @@ protected:
 typedef TypedArrayObject<Int8Adaptor, 1> Int8ArrayObjectWrapper;
 class Int8ArrayObject : public Int8ArrayObjectWrapper {
 public:
-    Int8ArrayObject(ExecutionState& state)
+    explicit Int8ArrayObject(ExecutionState& state)
         : Int8ArrayObjectWrapper(state)
     {
     }
@@ -345,7 +345,7 @@ public:
 typedef TypedArrayObject<Int16Adaptor, 2> Int16ArrayObjectWrapper;
 class Int16ArrayObject : public Int16ArrayObjectWrapper {
 public:
-    Int16ArrayObject(ExecutionState& state)
+    explicit Int16ArrayObject(ExecutionState& state)
         : Int16ArrayObjectWrapper(state)
     {
     }
@@ -357,7 +357,7 @@ public:
 typedef TypedArrayObject<Int32Adaptor, 4> Int32ArrayObjectWrapper;
 class Int32ArrayObject : public Int32ArrayObjectWrapper {
 public:
-    Int32ArrayObject(ExecutionState& state)
+    explicit Int32ArrayObject(ExecutionState& state)
         : Int32ArrayObjectWrapper(state)
     {
     }
@@ -369,7 +369,7 @@ public:
 typedef TypedArrayObject<Uint8Adaptor, 1> Uint8ArrayObjectWrapper;
 class Uint8ArrayObject : public Uint8ArrayObjectWrapper {
 public:
-    Uint8ArrayObject(ExecutionState& state)
+    explicit Uint8ArrayObject(ExecutionState& state)
         : Uint8ArrayObjectWrapper(state)
     {
     }
@@ -381,7 +381,7 @@ public:
 typedef TypedArrayObject<Uint16Adaptor, 2> Uint16ArrayObjectWrapper;
 class Uint16ArrayObject : public Uint16ArrayObjectWrapper {
 public:
-    Uint16ArrayObject(ExecutionState& state)
+    explicit Uint16ArrayObject(ExecutionState& state)
         : Uint16ArrayObjectWrapper(state)
     {
     }
@@ -393,7 +393,7 @@ public:
 typedef TypedArrayObject<Uint32Adaptor, 4> Uint32ArrayObjectWrapper;
 class Uint32ArrayObject : public Uint32ArrayObjectWrapper {
 public:
-    Uint32ArrayObject(ExecutionState& state)
+    explicit Uint32ArrayObject(ExecutionState& state)
         : Uint32ArrayObjectWrapper(state)
     {
     }
@@ -405,7 +405,7 @@ public:
 typedef TypedArrayObject<Uint8ClampedAdaptor, 1> Uint8ClampedArrayObjectWrapper;
 class Uint8ClampedArrayObject : public Uint8ClampedArrayObjectWrapper {
 public:
-    Uint8ClampedArrayObject(ExecutionState& state)
+    explicit Uint8ClampedArrayObject(ExecutionState& state)
         : Uint8ClampedArrayObjectWrapper(state)
     {
     }
@@ -417,7 +417,7 @@ public:
 typedef TypedArrayObject<Float32Adaptor, 4> Float32ArrayObjectWrapper;
 class Float32ArrayObject : public Float32ArrayObjectWrapper {
 public:
-    Float32ArrayObject(ExecutionState& state)
+    explicit Float32ArrayObject(ExecutionState& state)
         : Float32ArrayObjectWrapper(state)
     {
     }
@@ -429,7 +429,7 @@ public:
 typedef TypedArrayObject<Float64Adaptor, 8> Float64ArrayObjectWrapper;
 class Float64ArrayObject : public Float64ArrayObjectWrapper {
 public:
-    Float64ArrayObject(ExecutionState& state)
+    explicit Float64ArrayObject(ExecutionState& state)
         : Float64ArrayObjectWrapper(state)
     {
     }

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -87,15 +87,15 @@ public:
     enum FromPayloadTag { FromPayload };
 
     Value();
-    Value(ForceUninitializedTag);
-    Value(NullInitTag);
-    Value(UndefinedInitTag);
-    Value(EmptyValueInitTag);
-    Value(TrueInitTag);
-    Value(FalseInitTag);
+    explicit Value(ForceUninitializedTag);
+    explicit Value(NullInitTag);
+    explicit Value(UndefinedInitTag);
+    explicit Value(EmptyValueInitTag);
+    explicit Value(TrueInitTag);
+    explicit Value(FalseInitTag);
     explicit Value(FromPayloadTag, intptr_t ptr);
 #ifdef ESCARGOT_64
-    Value(PointerValue* ptr);
+    explicit Value(PointerValue* ptr);
     Value(const PointerValue* ptr);
 #else
     Value(PointerValue* ptr);
@@ -257,7 +257,7 @@ namespace std {
 
 template <>
 struct is_fundamental<Escargot::Value> {
-    operator bool() const
+    explicit operator bool() const
     {
         return true;
     }

--- a/src/runtime/WeakMapObject.h
+++ b/src/runtime/WeakMapObject.h
@@ -34,7 +34,7 @@ public:
         void* operator new[](size_t size) = delete;
     };
     typedef TightVector<WeakMapObjectDataItem*, GCUtil::gc_malloc_ignore_off_page_allocator<WeakMapObjectDataItem*>> WeakMapObjectData;
-    WeakMapObject(ExecutionState& state);
+    explicit WeakMapObject(ExecutionState& state);
 
     virtual bool isWeakMapObject() const
     {

--- a/src/runtime/WeakSetObject.h
+++ b/src/runtime/WeakSetObject.h
@@ -36,7 +36,7 @@ public:
     };
 
     typedef TightVector<WeakSetObjectDataItem*, GCUtil::gc_malloc_ignore_off_page_allocator<WeakSetObjectDataItem*>> WeakSetObjectData;
-    WeakSetObject(ExecutionState& state);
+    explicit WeakSetObject(ExecutionState& state);
 
     virtual bool isWeakSetObject() const
     {

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -31,7 +31,7 @@ public:
         m_size = 0;
     }
 
-    TightVector(size_t siz)
+    explicit TightVector(size_t siz)
     {
         m_buffer = nullptr;
         m_size = 0;

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -34,7 +34,7 @@ uint64_t timestamp(); // increase 1000 by 1 second
 
 class ProfilerTimer {
 public:
-    ProfilerTimer(const char *msg)
+    explicit ProfilerTimer(const char *msg)
     {
         m_start = longTickCount();
         m_msg = msg;

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -32,7 +32,7 @@ public:
         m_capacity = 0;
     }
 
-    Vector(size_t siz)
+    explicit Vector(size_t siz)
     {
         m_buffer = nullptr;
         m_size = 0;


### PR DESCRIPTION
"explicit" should be used on single-parameter constructors and conversion operators

https://sonarcloud.io/organizations/pando-project/issues?resolved=false&rules=cpp%3AS1709

Signed-off-by: Bence Gabor Kis <kisbg@inf.u-szeged.hu>