### PR TITLE
Reduce code smell around member access

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -670,7 +670,7 @@ public:
         return false;
     }
 
-protected:
+private:
     ExposableObjectGetOwnPropertyCallback m_getOwnPropetyCallback;
     ExposableObjectDefineOwnPropertyCallback m_defineOwnPropertyCallback;
     ExposableObjectEnumerationCallback m_enumerationCallback;

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -1043,7 +1043,7 @@ public:
         return new ControlFlowRecord(m_reason, m_value, m_count, m_outerLimitCount);
     }
 
-protected:
+private:
     ControlFlowReason m_reason;
     union {
         Value m_value;

--- a/src/parser/Script.h
+++ b/src/parser/Script.h
@@ -69,7 +69,7 @@ public:
         return m_topCodeBlock;
     }
 
-protected:
+private:
     Value executeLocal(ExecutionState& state, Value thisValue, InterpretedCodeBlock* parentCodeBlock, bool isEvalMode = false, bool needNewEnv = false);
     String* m_fileName;
     String* m_src;

--- a/src/parser/ScriptParser.h
+++ b/src/parser/ScriptParser.h
@@ -65,7 +65,7 @@ public:
     ScriptParserResult parse(StringView script, String* fileName = String::emptyString, InterpretedCodeBlock* parentCodeBlock = nullptr, bool strictFromOutside = false, bool isEvalCodeInFunction = false, size_t stackSizeRemain = SIZE_MAX);
     std::tuple<RefPtr<Node>, ASTScopeContext*> parseFunction(InterpretedCodeBlock* codeBlock, size_t stackSizeRemain, ExecutionState* state = nullptr);
 
-protected:
+private:
     InterpretedCodeBlock* generateCodeBlockTreeFromAST(Context* ctx, StringView source, Script* script, ProgramNode* program);
     InterpretedCodeBlock* generateCodeBlockTreeFromASTWalker(Context* ctx, StringView source, Script* script, ASTScopeContext* scopeCtx, InterpretedCodeBlock* parentCodeBlock);
     void generateCodeBlockTreeFromASTWalkerPostProcess(InterpretedCodeBlock* cb);


### PR DESCRIPTION
This first part is smaller, due to following reports almost all beeing in a distinct subdirectory
of these, so i wanted to avoid mixing those in. This seems a proper logical dividing point for me.
https://sonarcloud.io/organizations/pando-project/issues?open=AWfKGekKAVFeC0PaKxib&resolved=false&rules=cpp%3AS3656

Signed-off-by: Bela Toth <tbela@inf.u-szeged.hu>