### PR TITLE
Change check-tidy.py default clang format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - name: "check"
       addons:
         apt:
-          packages: [ clang-format-3.8 ]
+          packages: [ clang-format-3.9 ]
       script:
         - python tools/check_tidy.py
 
@@ -25,7 +25,7 @@ matrix:
         - ninja -Cout/darwin/x64/release
         - cp ./out/darwin/x64/release/escargot ./escargot
         - travis_wait tools/run-tests.py --arch=x86_64 test262
-        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal jsc-stress regression-tests v8 
+        - tools/run-tests.py --arch=x86_64 jetstream-only-cdjs sunspider-js internal jsc-stress regression-tests v8
         # FIXME: jetstream-only-simple and octane takes too long running time on darwin
         # jetstream-only-simple and octane are skipped now.
         # - travis_wait 40 tools/run-tests.py --arch=x86_64 jetstream-only-simple octane

--- a/src/runtime/GlobalObjectBuiltinRegExp.cpp
+++ b/src/runtime/GlobalObjectBuiltinRegExp.cpp
@@ -141,7 +141,7 @@ static Value builtinRegExpCompile(ExecutionState& state, Value thisValue, size_t
 }
 
 GlobalRegExpFunctionObject::GlobalRegExpFunctionObject(ExecutionState& state)
-    : FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().RegExp, builtinRegExpConstructor, 2, [](ExecutionState& state, CodeBlock * codeBlock, size_t argc, Value * argv) -> Object* {
+    : FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().RegExp, builtinRegExpConstructor, 2, [](ExecutionState& state, CodeBlock* codeBlock, size_t argc, Value* argv) -> Object* {
                          return new RegExpObject(state, String::emptyString, String::emptyString);
                      }),
                      FunctionObject::__ForBuiltin__)

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -103,7 +103,7 @@ def check_tidy(src_dir, update, clang_format, stats):
 
 def main():
     parser = ArgumentParser(description='Escargot Source Format Checker and Updater')
-    parser.add_argument('--clang-format', metavar='PATH', default='clang-format-3.8',
+    parser.add_argument('--clang-format', metavar='PATH', default='clang-format-3.9',
                         help='path to clang-format (default: %(default)s)')
     parser.add_argument('--update', action='store_true',
                         help='reformat files')


### PR DESCRIPTION
When installing clang-format with sudo , its not installing automatically Clang-format-3.8, but Clang-format-3.9 is installed instead. Also the code formatting in src/runtime/GlobalObjectBuiltinRegExp.cpp update to Clang-format-3.9 

Signed-off-by: Bence Gabor Kis <kisbg@inf.u-szeged.hu>