### PR TITLE
Reduce code smell around member access - Runtime (part1)

### DIFF
--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -82,7 +82,7 @@ public:
         return "Array";
     }
 
-protected:
+private:
     ALWAYS_INLINE bool isFastModeArray()
     {
         if (LIKELY(rareData() == nullptr)) {

--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -94,7 +94,7 @@ public:
         return m_string->bufferAccessData();
     }
 
-protected:
+private:
     void init(AtomicStringMap* ec, String* name);
     void init(AtomicStringMap* ec, const LChar* str, size_t len)
     {

--- a/src/runtime/BooleanObject.h
+++ b/src/runtime/BooleanObject.h
@@ -52,7 +52,7 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
 
-protected:
+private:
     bool m_primitiveValue;
 };
 }

--- a/src/runtime/Context.h
+++ b/src/runtime/Context.h
@@ -207,7 +207,7 @@ public:
         return m_securityPolicyCheckCallback;
     }
 
-protected:
+private:
     VMInstance* m_instance;
 
     // these data actually store in VMInstance

--- a/src/runtime/Environment.h
+++ b/src/runtime/Environment.h
@@ -59,7 +59,7 @@ public:
         return true;
     }
 
-protected:
+private:
     EnvironmentRecord* m_record;
     LexicalEnvironment* m_outerEnvironment;
 };

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -242,7 +242,7 @@ public:
         return m_bindingObject->deleteOwnProperty(state, name);
     }
 
-protected:
+private:
     Object* m_bindingObject;
 };
 
@@ -274,7 +274,7 @@ public:
         return m_globalCodeBlock;
     }
 
-protected:
+private:
     InterpretedCodeBlock* m_globalCodeBlock;
     GlobalObject* m_globalObject;
 };
@@ -376,7 +376,7 @@ public:
 
     virtual void initializeBinding(ExecutionState& state, const AtomicString& name, const Value& V);
 
-protected:
+private:
     SmallValueVector m_heapStorage;
     IdentifierRecordVector m_recordVector;
 };
@@ -540,7 +540,7 @@ public:
         return m_argv;
     }
 
-protected:
+private:
     size_t m_argc;
     Value* m_argv;
     SmallValueTightVector m_heapStorage;
@@ -617,7 +617,7 @@ public:
 
     virtual void initializeBinding(ExecutionState& state, const AtomicString& name, const Value& V);
 
-protected:
+private:
     size_t m_argc;
     Value* m_argv;
     SmallValueTightVector m_heapStorage;


### PR DESCRIPTION
First part of the code smell reducing in src/runtime.

https://sonarcloud.io/organizations/pando-project/issues?open=AWfKGekKAVFeC0PaKxib&resolved=false&rules=cpp%3AS3656

Signed-off-by: Bela Toth tbela@inf.u-szeged.hu