### PR TITLE
Primitive types should use the same representation for Value and SmallValue

### DIFF
--- a/src/runtime/SmallValue.h
+++ b/src/runtime/SmallValue.h
@@ -213,7 +213,11 @@ public:
         if (HAS_OBJECT_TAG(m_data.payload)) {
             PointerValue* v = (PointerValue*)m_data.payload;
             if (((size_t)v) <= ValueLast) {
-                Value(v);
+#ifdef ESCARGOT_32
+                return Value(Value::FromTag, ~((uint32_t)v));
+#else
+                return Value(v);
+#endif
             } else if (g_doubleInSmallValueTag == *((size_t*)v)) {
                 return Value(v->asDoubleInSmallValue()->value());
             }
@@ -286,7 +290,11 @@ public:
                 }
                 m_data.payload = reinterpret_cast<intptr_t>(new DoubleInSmallValue(from.asNumber()));
             } else {
+#ifdef ESCARGOT_32
+                m_data.payload = ~from.tag();
+#else
                 m_data.payload = from.payload();
+#endif
             }
         }
     }
@@ -306,7 +314,11 @@ protected:
             } else if (from.isNumber()) {
                 m_data.payload = reinterpret_cast<intptr_t>(new DoubleInSmallValue(from.asNumber()));
             } else {
+#ifdef ESCARGOT_32
+                m_data.payload = ~from.tag();
+#else
                 m_data.payload = from.payload();
+#endif
             }
         }
     }

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -219,16 +219,14 @@ public:
 
 // All non-numeric (bool, null, undefined) immediates have bit 2 set.
 #define TagBitTypeOther 0x2ll
-#define TagBitBool 0x4ll
-#define TagBitUndefined 0x8ll
-// Combined integer value for non-numeric immediates.
-#define ValueFalse (TagBitTypeOther | TagBitBool | false)
-#define ValueTrue (TagBitTypeOther | TagBitBool | true)
-#define ValueUndefined (TagBitTypeOther | TagBitUndefined)
-#define ValueNull (TagBitTypeOther)
+#define TagTypeShift 2
 
-// TagMask is used to check for all types of immediate values (either number or 'other').
-#define TagMask (TagTypeNumber | TagBitTypeOther)
+// Combined integer value for non-numeric immediates.
+#define ValueFalse (TagBitTypeOther | (0 << TagTypeShift))
+#define ValueTrue (TagBitTypeOther | (1 << TagTypeShift))
+#define ValueUndefined (TagBitTypeOther | (2 << TagTypeShift))
+#define ValueNull (TagBitTypeOther | (3 << TagTypeShift))
+#define ValueLast ValueNull
 
 // These special values are never visible to JavaScript code; Empty is used to represent
 // Array holes, and for uninitialized Values. Deleted is used in hash table code.
@@ -236,7 +234,11 @@ public:
 // pointer should have either of these values (Empty is null, deleted is at an invalid
 // alignment for a GC cell, and in the zero page).
 #define ValueEmpty 0x0ll
-#define ValueDeleted 0x4ll
+
+// TagMask is used to check for all types of immediate values (either number or 'other').
+#define TagMask (TagTypeNumber | TagBitTypeOther)
+
+    intptr_t payload() const;
 #endif
 
 private:

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -352,7 +352,7 @@ inline Value::Value(FromPayloadTag, intptr_t ptr)
 
 inline Value::Value(bool b)
 {
-    u.asInt64 = (TagBitTypeOther | TagBitBool | b);
+    u.asInt64 = (TagBitTypeOther | (b << TagTypeShift));
 }
 
 inline Value::Value(PointerValue* ptr)
@@ -525,6 +525,11 @@ inline bool Value::isFunction() const
 inline FunctionObject* Value::asFunction() const
 {
     return asPointerValue()->asFunctionObject();
+}
+
+inline intptr_t Value::payload() const
+{
+    return u.asInt64;
 }
 
 #endif

--- a/src/runtime/ValueInlines.h
+++ b/src/runtime/ValueInlines.h
@@ -77,20 +77,20 @@ inline Value::Value(EmptyValueInitTag)
 
 inline Value::Value(TrueInitTag)
 {
-    u.asBits.tag = BooleanTag;
-    u.asBits.payload = 1;
+    u.asBits.tag = BooleanTrueTag;
+    u.asBits.payload = 0;
 }
 
 inline Value::Value(FalseInitTag)
 {
-    u.asBits.tag = BooleanTag;
+    u.asBits.tag = BooleanFalseTag;
     u.asBits.payload = 0;
 }
 
 inline Value::Value(bool b)
 {
-    u.asBits.tag = BooleanTag;
-    u.asBits.payload = b;
+    u.asBits.tag = BooleanFalseTag ^ (((uint32_t)b) << TagTypeShift);
+    u.asBits.payload = 0;
 }
 
 inline Value::Value(FromPayloadTag, intptr_t ptr)
@@ -152,6 +152,15 @@ inline Value::Value(const Object* ptr)
     u.asBits.payload = reinterpret_cast<int32_t>(const_cast<Object*>(ptr));
 }
 
+inline Value::Value(FromTagTag, uint32_t tag)
+{
+    ASSERT(tag == BooleanFalseTag || tag == BooleanTrueTag || tag == NullTag
+           || tag == UndefinedTag || tag == EmptyValueTag);
+
+    u.asBits.tag = tag;
+    u.asBits.payload = 0;
+}
+
 inline Value::Value(EncodeAsDoubleTag, double d)
 {
     u.asDouble = d;
@@ -207,7 +216,7 @@ inline int32_t Value::asInt32() const
 inline bool Value::asBoolean() const
 {
     ASSERT(isBoolean());
-    return u.asBits.payload;
+    return u.asBits.tag == BooleanTrueTag;
 }
 
 inline double Value::asDouble() const
@@ -243,17 +252,21 @@ inline bool Value::isNull() const
 
 inline bool Value::isBoolean() const
 {
-    return tag() == BooleanTag;
+    /* BooleanTrueTag and BooleanFalseTag are inverted values
+       of ValueTrue and ValueFalse respectively. */
+    COMPILE_ASSERT(BooleanFalseTag == (BooleanTrueTag | (1 << TagTypeShift)), "");
+
+    return (tag() | (1 << TagTypeShift)) == BooleanFalseTag;
 }
 
 inline bool Value::isTrue() const
 {
-    return tag() == BooleanTag && asBoolean();
+    return tag() == BooleanTrueTag;
 }
 
 inline bool Value::isFalse() const
 {
-    return tag() == BooleanTag && !asBoolean();
+    return tag() == BooleanFalseTag;
 }
 
 inline PointerValue* Value::asPointerValue() const
@@ -488,7 +501,9 @@ inline bool Value::isNull() const
 
 inline bool Value::isBoolean() const
 {
-    return u.asInt64 == ValueTrue || u.asInt64 == ValueFalse;
+    COMPILE_ASSERT(ValueTrue == (ValueFalse | (1 << TagTypeShift)), "");
+
+    return (u.asInt64 | (1 << TagTypeShift)) == ValueTrue;
 }
 
 inline bool Value::isTrue() const
@@ -723,16 +738,8 @@ inline bool Value::equalsTo(ExecutionState& state, const Value& val) const
 
 inline bool Value::toBoolean(ExecutionState& ec) const // $7.1.2 ToBoolean
 {
-#ifdef ESCARGOT_32
-    if (LIKELY(isBoolean()))
-        return payload();
-#else
-    if (*this == Value(true))
-        return true;
-
-    if (*this == Value(false))
-        return false;
-#endif
+    if (isBoolean())
+        return asBoolean();
 
     if (isInt32())
         return asInt32();


### PR DESCRIPTION
Start with 64 bit first.