### PR TITLE
Eliminate the memory copier code duplications in the Vector classes.

### DIFF
--- a/src/runtime/AtomicString.h
+++ b/src/runtime/AtomicString.h
@@ -134,11 +134,7 @@ typedef TightVector<AtomicString, GCUtil::gc_malloc_atomic_ignore_off_page_alloc
 namespace std {
 
 template <>
-struct is_fundamental<Escargot::AtomicString> {
-    operator bool() const
-    {
-        return true;
-    }
+struct is_fundamental<Escargot::AtomicString> : public true_type {
 };
 }
 

--- a/src/runtime/ObjectStructure.h
+++ b/src/runtime/ObjectStructure.h
@@ -330,19 +330,11 @@ inline ObjectStructure* ObjectStructure::convertToWithFastAccess(ExecutionState&
 namespace std {
 
 template <>
-struct is_fundamental<Escargot::ObjectStructureItem> {
-    operator bool() const
-    {
-        return true;
-    }
+struct is_fundamental<Escargot::ObjectStructureItem> : public true_type {
 };
 
 template <>
-struct is_fundamental<Escargot::ObjectStructureTransitionItem> {
-    operator bool() const
-    {
-        return true;
-    }
+struct is_fundamental<Escargot::ObjectStructureTransitionItem> : public true_type {
 };
 }
 #endif

--- a/src/runtime/SmallValue.h
+++ b/src/runtime/SmallValue.h
@@ -387,11 +387,7 @@ typedef TightVector<SmallValue, GCUtil::gc_malloc_ignore_off_page_allocator<Smal
 namespace std {
 
 template <>
-struct is_fundamental<Escargot::SmallValue> {
-    explicit operator bool() const
-    {
-        return true;
-    }
+struct is_fundamental<Escargot::SmallValue> : public true_type {
 };
 }
 

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -256,11 +256,7 @@ typedef Vector<Value, CustomAllocator<Value>> ValueVector;
 namespace std {
 
 template <>
-struct is_fundamental<Escargot::Value> {
-    explicit operator bool() const
-    {
-        return true;
-    }
+struct is_fundamental<Escargot::Value> : public true_type {
 };
 }
 

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -51,14 +51,7 @@ public:
         if (other.size()) {
             m_size = other.size();
             m_buffer = Allocator().allocate(m_size);
-
-            if (std::is_fundamental<T>()) {
-                memcpy(m_buffer, other.m_buffer, sizeof(T) * m_size);
-            } else {
-                for (size_t i = 0; i < m_size; i++) {
-                    m_buffer[i] = other[i];
-                }
-            }
+            VectorCopier<T>::copy(m_buffer, other.data(), m_size);
         } else {
             m_buffer = nullptr;
             m_size = 0;
@@ -73,13 +66,7 @@ public:
         if (other.size()) {
             m_size = other.size();
             m_buffer = Allocator().allocate(m_size);
-            if (std::is_fundamental<T>()) {
-                memcpy(m_buffer, other.m_buffer, sizeof(T) * m_size);
-            } else {
-                for (size_t i = 0; i < m_size; i++) {
-                    m_buffer[i] = other[i];
-                }
-            }
+            VectorCopier<T>::copy(m_buffer, other.data(), m_size);
         } else {
             clear();
         }
@@ -90,13 +77,8 @@ public:
     {
         m_size = other.size() + 1;
         m_buffer = Allocator().allocate(m_size);
-        if (std::is_fundamental<T>()) {
-            memcpy(m_buffer, other.data(), sizeof(T) * other.size());
-        } else {
-            for (size_t i = 0; i < other.size(); i++) {
-                m_buffer[i] = other[i];
-            }
-        }
+        VectorCopier<T>::copy(m_buffer, other.data(), other.size());
+
         m_buffer[other.size()] = newItem;
     }
 
@@ -109,13 +91,7 @@ public:
     void pushBack(const T& val)
     {
         T* newBuffer = Allocator().allocate(m_size + 1);
-        if (std::is_fundamental<T>()) {
-            memcpy(newBuffer, m_buffer, sizeof(T) * m_size);
-        } else {
-            for (size_t i = 0; i < m_size; i++) {
-                newBuffer[i] = m_buffer[i];
-            }
-        }
+        VectorCopier<T>::copy(newBuffer, m_buffer, m_size);
 
         newBuffer[m_size] = val;
         if (m_buffer)
@@ -133,13 +109,11 @@ public:
     {
         ASSERT(pos <= m_size);
         T* newBuffer = Allocator().allocate(m_size + 1);
-        for (size_t i = 0; i < pos; i++) {
-            newBuffer[i] = m_buffer[i];
-        }
+
+        VectorCopier<T>::copy(newBuffer, m_buffer, pos);
         newBuffer[pos] = val;
-        for (size_t i = pos; i < m_size; i++) {
-            newBuffer[i + 1] = m_buffer[i];
-        }
+        VectorCopier<T>::copy(&newBuffer[pos + 1], m_buffer + pos, m_size - pos);
+
         if (m_buffer)
             Allocator().deallocate(m_buffer, m_size);
         m_buffer = newBuffer;
@@ -160,13 +134,8 @@ public:
         size_t c = end - start;
         if (m_size - c) {
             T* newBuffer = Allocator().allocate(m_size - c);
-            for (size_t i = 0; i < start; i++) {
-                newBuffer[i] = m_buffer[i];
-            }
-
-            for (size_t i = end; i < m_size; i++) {
-                newBuffer[i - c] = m_buffer[i];
-            }
+            VectorCopier<T>::copy(newBuffer, m_buffer, start);
+            VectorCopier<T>::copy(&newBuffer[end - c], &m_buffer[end], m_size - end);
 
             if (m_buffer)
                 Allocator().deallocate(m_buffer, m_size);
@@ -217,6 +186,11 @@ public:
         return m_buffer;
     }
 
+    const T* data() const
+    {
+        return m_buffer;
+    }
+
     T& back()
     {
         return m_buffer[m_size - 1];
@@ -234,14 +208,7 @@ public:
     {
         if (newSize) {
             T* newBuffer = Allocator().allocate(newSize);
-
-            if (std::is_fundamental<T>()) {
-                memcpy(newBuffer, m_buffer, sizeof(T) * std::min(m_size, newSize));
-            } else {
-                for (size_t i = 0; i < m_size && i < newSize; i++) {
-                    newBuffer[i] = m_buffer[i];
-                }
-            }
+            VectorCopier<T>::copy(newBuffer, m_buffer, std::min(m_size, newSize));
 
             if (m_buffer)
                 Allocator().deallocate(m_buffer, m_size);
@@ -259,14 +226,7 @@ public:
     {
         if (newSize) {
             T* newBuffer = Allocator().allocate(newSize);
-
-            if (std::is_fundamental<T>()) {
-                memcpy(newBuffer, m_buffer, sizeof(T) * std::min(m_size, newSize));
-            } else {
-                for (size_t i = 0; i < m_size && i < newSize; i++) {
-                    newBuffer[i] = m_buffer[i];
-                }
-            }
+            VectorCopier<T>::copy(newBuffer, m_buffer, std::min(m_size, newSize));
 
             for (size_t i = m_size; i < newSize; i++) {
                 newBuffer[i] = val;
@@ -319,14 +279,8 @@ public:
     void pushBack(const T& val, size_t newSize)
     {
         T* newBuffer = Allocator().allocate(newSize);
+        VectorCopier<T>::copy(newBuffer, m_buffer, newSize - 1);
 
-        if (std::is_fundamental<T>()) {
-            memcpy(newBuffer, m_buffer, sizeof(T) * (newSize - 1));
-        } else {
-            for (size_t i = 0; i < newSize - 1; i++) {
-                newBuffer[i] = m_buffer[i];
-            }
-        }
         newBuffer[newSize - 1] = val;
         if (m_buffer)
             Allocator().deallocate(m_buffer);
@@ -352,10 +306,7 @@ public:
     {
         if (newSize) {
             T* newBuffer = Allocator().allocate(newSize);
-
-            for (size_t i = 0; i < oldSize && i < newSize; i++) {
-                newBuffer[i] = m_buffer[i];
-            }
+            VectorCopier<T>::copy(newBuffer, m_buffer, std::min(oldSize, newSize));
 
             if (m_buffer)
                 Allocator().deallocate(m_buffer, oldSize);
@@ -381,13 +332,8 @@ public:
         size_t c = end - start;
         if (currentSize - c) {
             T* newBuffer = Allocator().allocate(currentSize - c);
-            for (size_t i = 0; i < start; i++) {
-                newBuffer[i] = m_buffer[i];
-            }
-
-            for (size_t i = end; i < currentSize; i++) {
-                newBuffer[i - c] = m_buffer[i];
-            }
+            VectorCopier<T>::copy(newBuffer, m_buffer, start);
+            VectorCopier<T>::copy(&newBuffer[end - c], &m_buffer[end], currentSize - end);
 
             if (m_buffer)
                 Allocator().deallocate(m_buffer, currentSize);


### PR DESCRIPTION
Introduced a new template VectorCopier class that has specializations for the `memcpy` and the `copy constructor` cases.