### PR TITLE
Add RegExp.compile() function

### DIFF
--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -87,8 +87,10 @@ public:
 
     explicit RegExpObject(ExecutionState& state);
     RegExpObject(ExecutionState& state, String* source, String* option);
+    RegExpObject(ExecutionState& state, String* source, unsigned int option);
 
     void init(ExecutionState& state, String* source, String* option);
+    void initWithOption(ExecutionState& state, String* source, Option option);
 
     double computedLastIndex(ExecutionState& state)
     {
@@ -157,6 +159,7 @@ private:
     }
 
     void setOption(const Option& option);
+    void internalInit(ExecutionState& state, String* source);
 
     static RegExpCacheEntry& getCacheEntryAndCompileIfNeeded(ExecutionState& state, String* source, const Option& option);
 


### PR DESCRIPTION
This patch adds RegExp.compile() function.
Since the given argument can be a RegExp object as well, which already has their option flags parsed there was a need to add a new init function which doesn't parse flags and accepts an `unsigned int` as its parameter.

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>