### PR TITLE
Add ES6 RegExp.prototype.exec() method

### DIFF
--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -185,7 +185,7 @@ void RegExpObject::initWithOption(ExecutionState& state, String* source, Option 
 
 void RegExpObject::setLastIndex(ExecutionState& state, const Value& v)
 {
-    if (UNLIKELY(rareData() && rareData()->m_hasNonWritableLastIndexRegexpObject)) {
+    if (UNLIKELY(rareData() && rareData()->m_hasNonWritableLastIndexRegexpObject && (m_option & (Option::Sticky | Option::Global)))) {
         Object::throwCannotWriteError(state, PropertyName(state.context()->staticStrings().lastIndex));
     }
     m_lastIndex = v;
@@ -413,11 +413,7 @@ bool RegExpObject::match(ExecutionState& state, String* str, RegexMatchResult& m
         }
     } while (result != JSC::Yarr::offsetNoMatch);
 
-    if (!gotResult && ((option() & RegExpObject::Global) || (option() & RegExpObject::Sticky))) {
-        setLastIndex(state, Value(0));
-    }
-
-    if (!(option() & RegExpObject::Global) && reachToEnd) {
+    if (!gotResult && ((option() & (RegExpObject::Option::Global | RegExpObject::Option::Sticky)))) {
         setLastIndex(state, Value(0));
     }
 

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -193,6 +193,8 @@ namespace Escargot {
     F(ignoreCase)                 \
     F(global)                     \
     F(multiline)                  \
+    F(sticky)                     \
+    F(unicode)                    \
     F(implements)                 \
     F(interface)                  \
     F(package)                    \

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -146,6 +146,24 @@ Value VMInstance::regexpMultilineNativeGetter(ExecutionState& state, Object* sel
 static ObjectPropertyNativeGetterSetterData regexpMultilineGetterData(
     false, false, false, &VMInstance::regexpMultilineNativeGetter, &VMInstance::undefinedNativeSetter);
 
+Value VMInstance::regexpStickyNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
+{
+    ASSERT(self->isRegExpObject());
+    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::Sticky));
+}
+
+static ObjectPropertyNativeGetterSetterData regexpStickyGetterData(
+    false, false, false, &VMInstance::regexpStickyNativeGetter, &VMInstance::undefinedNativeSetter);
+
+Value VMInstance::regexpUnicodeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
+{
+    ASSERT(self->isRegExpObject());
+    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::Unicode));
+}
+
+static ObjectPropertyNativeGetterSetterData regexpUnicodeGetterData(
+    false, false, false, &VMInstance::regexpUnicodeNativeGetter, &VMInstance::undefinedNativeSetter);
+
 Value VMInstance::regexpLastIndexNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
     ASSERT(self->isRegExpObject());
@@ -299,6 +317,10 @@ VMInstance::VMInstance(const char* locale, const char* timezone)
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpIgnoreCaseGetterData));
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.multiline,
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpMultilineGetterData));
+    m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.sticky,
+                                                                                       ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpStickyGetterData));
+    m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.unicode,
+                                                                                       ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpUnicodeGetterData));
 
     m_defaultStructureForArgumentsObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
     m_defaultStructureForArgumentsObject = m_defaultStructureForArgumentsObject->addProperty(stateForInit, m_staticStrings.callee, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -161,6 +161,8 @@ public:
     static Value regexpGlobalNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpIgnoreCaseNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpMultilineNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
+    static Value regexpStickyNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
+    static Value regexpUnicodeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
 
     bool didSomePrototypeObjectDefineIndexedProperty()
     {

--- a/test/es2015/regexp-utf16.js
+++ b/test/es2015/regexp-utf16.js
@@ -1,0 +1,18 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var r = /./ug;
+r.exec('𝌆');
+assert(r.lastIndex, 2);


### PR DESCRIPTION
Add ES6 support to RegExp.prototype.exec method.
Also fix regexp-lastIndex.js test in v8.

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>