### PR TITLE
Pass const primitive values by value rather than reference

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -590,12 +590,12 @@ void ValueVectorRef::erase(size_t start, size_t end)
     toImpl(this)->erase(start, end);
 }
 
-ValueRef* ValueVectorRef::at(const size_t& idx)
+ValueRef* ValueVectorRef::at(const size_t idx)
 {
     return reinterpret_cast<ValueRef*>((*toImpl(this))[idx].payload());
 }
 
-void ValueVectorRef::set(const size_t& idx, ValueRef* newValue)
+void ValueVectorRef::set(const size_t idx, ValueRef* newValue)
 {
     toImpl(this)->data()[idx] = SmallValue::fromPayload(newValue);
 }
@@ -1249,7 +1249,7 @@ bool FunctionObjectRef::isConstructor()
     return o->isConstructor();
 }
 
-ValueRef* FunctionObjectRef::call(ExecutionStateRef* state, ValueRef* receiver, const size_t& argc, ValueRef** argv)
+ValueRef* FunctionObjectRef::call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv)
 {
     FunctionObject* o = toImpl(this);
     Value* newArgv = ALLOCA(sizeof(Value) * argc, Value, state);
@@ -1259,7 +1259,7 @@ ValueRef* FunctionObjectRef::call(ExecutionStateRef* state, ValueRef* receiver, 
     return toRef(o->call(*toImpl(state), toImpl(receiver), argc, newArgv));
 }
 
-ObjectRef* FunctionObjectRef::newInstance(ExecutionStateRef* state, const size_t& argc, ValueRef** argv)
+ObjectRef* FunctionObjectRef::newInstance(ExecutionStateRef* state, const size_t argc, ValueRef** argv)
 {
     FunctionObject* o = toImpl(this);
     Value* newArgv = ALLOCA(sizeof(Value) * argc, Value, state);

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -391,8 +391,8 @@ public:
     void insert(size_t pos, ValueRef* val);
     void erase(size_t pos);
     void erase(size_t start, size_t end);
-    ValueRef* at(const size_t& idx);
-    void set(const size_t& idx, ValueRef* newValue);
+    ValueRef* at(const size_t idx);
+    void set(const size_t idx, ValueRef* newValue);
     void resize(size_t newSize);
 };
 
@@ -652,9 +652,9 @@ public:
     bool setFunctionPrototype(ExecutionStateRef* state, ValueRef* v);
 
     bool isConstructor();
-    ValueRef* call(ExecutionStateRef* state, ValueRef* receiver, const size_t& argc, ValueRef** argv);
+    ValueRef* call(ExecutionStateRef* state, ValueRef* receiver, const size_t argc, ValueRef** argv);
     // ECMAScript new operation
-    ObjectRef* newInstance(ExecutionStateRef* state, const size_t& argc, ValueRef** argv);
+    ObjectRef* newInstance(ExecutionStateRef* state, const size_t argc, ValueRef** argv);
 
     void markFunctionNeedsSlowVirtualIdentifierOperation();
 };

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -193,7 +193,7 @@ public:
 
 class LoadLiteral : public ByteCode {
 public:
-    LoadLiteral(const ByteCodeLOC& loc, const size_t& registerIndex, const Value& v)
+    LoadLiteral(const ByteCodeLOC& loc, const size_t registerIndex, const Value& v)
         : ByteCode(Opcode::LoadLiteralOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_value(v)
@@ -226,7 +226,7 @@ public:
 
 class LoadByName : public ByteCode {
 public:
-    LoadByName(const ByteCodeLOC& loc, const size_t& registerIndex, const AtomicString& name)
+    LoadByName(const ByteCodeLOC& loc, const size_t registerIndex, const AtomicString& name)
         : ByteCode(Opcode::LoadByNameOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_name(name)
@@ -245,7 +245,7 @@ public:
 
 class StoreByName : public ByteCode {
 public:
-    StoreByName(const ByteCodeLOC& loc, const size_t& registerIndex, const AtomicString& name)
+    StoreByName(const ByteCodeLOC& loc, const size_t registerIndex, const AtomicString& name)
         : ByteCode(Opcode::StoreByNameOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_name(name)
@@ -264,7 +264,7 @@ public:
 
 class LoadByHeapIndex : public ByteCode {
 public:
-    LoadByHeapIndex(const ByteCodeLOC& loc, const size_t& registerIndex, const size_t& upperIndex, const size_t& index)
+    LoadByHeapIndex(const ByteCodeLOC& loc, const size_t registerIndex, const size_t upperIndex, const size_t index)
         : ByteCode(Opcode::LoadByHeapIndexOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_upperIndex(upperIndex)
@@ -285,7 +285,7 @@ public:
 
 class StoreByHeapIndex : public ByteCode {
 public:
-    StoreByHeapIndex(const ByteCodeLOC& loc, const size_t& registerIndex, const size_t& upperIndex, const size_t& index)
+    StoreByHeapIndex(const ByteCodeLOC& loc, const size_t registerIndex, const size_t upperIndex, const size_t index)
         : ByteCode(Opcode::StoreByHeapIndexOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_upperIndex(upperIndex)
@@ -323,7 +323,7 @@ public:
 
 class CreateFunction : public ByteCode {
 public:
-    CreateFunction(const ByteCodeLOC& loc, const size_t& registerIndex, CodeBlock* cb)
+    CreateFunction(const ByteCodeLOC& loc, const size_t registerIndex, CodeBlock* cb)
         : ByteCode(Opcode::CreateFunctionOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_codeBlock(cb)
@@ -350,20 +350,20 @@ public:
     }
 #endif
 
-#define DEFINE_BINARY_OPERATION(CodeName, HumanName)                                                                                         \
-    class Binary##CodeName : public ByteCode {                                                                                               \
-    public:                                                                                                                                  \
-        Binary##CodeName(const ByteCodeLOC& loc, const size_t& registerIndex0, const size_t& registerIndex1, const size_t& dstRegisterIndex) \
-            : ByteCode(Opcode::Binary##CodeName##Opcode, loc)                                                                                \
-            , m_srcIndex0(registerIndex0)                                                                                                    \
-            , m_srcIndex1(registerIndex1)                                                                                                    \
-            , m_dstIndex(dstRegisterIndex)                                                                                                   \
-        {                                                                                                                                    \
-        }                                                                                                                                    \
-        ByteCodeRegisterIndex m_srcIndex0;                                                                                                   \
-        ByteCodeRegisterIndex m_srcIndex1;                                                                                                   \
-        ByteCodeRegisterIndex m_dstIndex;                                                                                                    \
-        DEFINE_BINARY_OPERATION_DUMP(HumanName)                                                                                              \
+#define DEFINE_BINARY_OPERATION(CodeName, HumanName)                                                                                      \
+    class Binary##CodeName : public ByteCode {                                                                                            \
+    public:                                                                                                                               \
+        Binary##CodeName(const ByteCodeLOC& loc, const size_t registerIndex0, const size_t registerIndex1, const size_t dstRegisterIndex) \
+            : ByteCode(Opcode::Binary##CodeName##Opcode, loc)                                                                             \
+            , m_srcIndex0(registerIndex0)                                                                                                 \
+            , m_srcIndex1(registerIndex1)                                                                                                 \
+            , m_dstIndex(dstRegisterIndex)                                                                                                \
+        {                                                                                                                                 \
+        }                                                                                                                                 \
+        ByteCodeRegisterIndex m_srcIndex0;                                                                                                \
+        ByteCodeRegisterIndex m_srcIndex1;                                                                                                \
+        ByteCodeRegisterIndex m_dstIndex;                                                                                                 \
+        DEFINE_BINARY_OPERATION_DUMP(HumanName)                                                                                           \
     };
 
 DEFINE_BINARY_OPERATION(Plus, "plus");
@@ -391,7 +391,7 @@ DEFINE_BINARY_OPERATION(InstanceOfOperation, "instance of");
 
 class CreateObject : public ByteCode {
 public:
-    CreateObject(const ByteCodeLOC& loc, const size_t& registerIndex)
+    CreateObject(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::CreateObjectOpcode, loc)
         , m_registerIndex(registerIndex)
     {
@@ -409,7 +409,7 @@ public:
 
 class CreateArray : public ByteCode {
 public:
-    CreateArray(const ByteCodeLOC& loc, const size_t& registerIndex)
+    CreateArray(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::CreateArrayOpcode, loc)
         , m_registerIndex(registerIndex)
     {
@@ -429,7 +429,7 @@ public:
 
 class GetObject : public ByteCode {
 public:
-    GetObject(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, const size_t& propertyRegisterIndex, const size_t& storeRegisterIndex)
+    GetObject(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyRegisterIndex, const size_t storeRegisterIndex)
         : ByteCode(Opcode::GetObjectOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_propertyRegisterIndex(propertyRegisterIndex)
@@ -451,7 +451,7 @@ public:
 
 class SetObjectOperation : public ByteCode {
 public:
-    SetObjectOperation(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, const size_t& propertyRegisterIndex, const size_t& loadRegisterIndex)
+    SetObjectOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyRegisterIndex, const size_t loadRegisterIndex)
         : ByteCode(Opcode::SetObjectOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_propertyRegisterIndex(propertyRegisterIndex)
@@ -473,7 +473,7 @@ public:
 
 class ObjectDefineOwnPropertyOperation : public ByteCode {
 public:
-    ObjectDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, const size_t& propertyRegisterIndex, const size_t& loadRegisterIndex)
+    ObjectDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t propertyRegisterIndex, const size_t loadRegisterIndex)
         : ByteCode(Opcode::ObjectDefineOwnPropertyOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_propertyRegisterIndex(propertyRegisterIndex)
@@ -495,7 +495,7 @@ public:
 
 class ObjectDefineOwnPropertyWithNameOperation : public ByteCode {
 public:
-    ObjectDefineOwnPropertyWithNameOperation(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, AtomicString propertyName, const size_t& loadRegisterIndex)
+    ObjectDefineOwnPropertyWithNameOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, AtomicString propertyName, const size_t loadRegisterIndex)
         : ByteCode(Opcode::ObjectDefineOwnPropertyWithNameOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_loadRegisterIndex(loadRegisterIndex)
@@ -519,7 +519,7 @@ public:
 
 class ArrayDefineOwnPropertyOperation : public ByteCode {
 public:
-    ArrayDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, const uint32_t& baseIndex, uint8_t count)
+    ArrayDefineOwnPropertyOperation(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const uint32_t baseIndex, uint8_t count)
         : ByteCode(Opcode::ArrayDefineOwnPropertyOperationOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_count(count)
@@ -606,7 +606,7 @@ struct GetObjectInlineCache {
 class GetObjectPreComputedCase : public ByteCode {
 public:
     // [object] -> [value]
-    GetObjectPreComputedCase(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, const size_t& storeRegisterIndex, PropertyName propertyName)
+    GetObjectPreComputedCase(const ByteCodeLOC& loc, const size_t objectRegisterIndex, const size_t storeRegisterIndex, PropertyName propertyName)
         : ByteCode(Opcode::GetObjectPreComputedCaseOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_storeRegisterIndex(storeRegisterIndex)
@@ -651,7 +651,7 @@ struct SetObjectInlineCache {
 
 class SetObjectPreComputedCase : public ByteCode {
 public:
-    SetObjectPreComputedCase(const ByteCodeLOC& loc, const size_t& objectRegisterIndex, PropertyName propertyName, const size_t& loadRegisterIndex, SetObjectInlineCache* inlineCache)
+    SetObjectPreComputedCase(const ByteCodeLOC& loc, const size_t objectRegisterIndex, PropertyName propertyName, const size_t loadRegisterIndex, SetObjectInlineCache* inlineCache)
         : ByteCode(Opcode::SetObjectPreComputedCaseOpcode, loc)
         , m_objectRegisterIndex(objectRegisterIndex)
         , m_loadRegisterIndex(loadRegisterIndex)
@@ -674,7 +674,7 @@ public:
 
 class GetGlobalObject : public ByteCode {
 public:
-    GetGlobalObject(const ByteCodeLOC& loc, const size_t& registerIndex, PropertyName propertyName)
+    GetGlobalObject(const ByteCodeLOC& loc, const size_t registerIndex, PropertyName propertyName)
         : ByteCode(Opcode::GetGlobalObjectOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_propertyName(propertyName)
@@ -698,7 +698,7 @@ public:
 
 class SetGlobalObject : public ByteCode {
 public:
-    SetGlobalObject(const ByteCodeLOC& loc, const size_t& registerIndex, PropertyName propertyName)
+    SetGlobalObject(const ByteCodeLOC& loc, const size_t registerIndex, PropertyName propertyName)
         : ByteCode(Opcode::SetGlobalObjectOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_propertyName(propertyName)
@@ -723,7 +723,7 @@ public:
 
 class Move : public ByteCode {
 public:
-    Move(const ByteCodeLOC& loc, const size_t& registerIndex0, const size_t& registerIndex1) // 1 <= 0
+    Move(const ByteCodeLOC& loc, const size_t registerIndex0, const size_t registerIndex1) // 1 <= 0
         : ByteCode(Opcode::MoveOpcode, loc),
           m_registerIndex0(registerIndex0),
           m_registerIndex1(registerIndex1)
@@ -743,7 +743,7 @@ public:
 
 class ToNumber : public ByteCode {
 public:
-    ToNumber(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    ToNumber(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::ToNumberOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -763,7 +763,7 @@ public:
 
 class Increment : public ByteCode {
 public:
-    Increment(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    Increment(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::IncrementOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -783,7 +783,7 @@ public:
 
 class Decrement : public ByteCode {
 public:
-    Decrement(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    Decrement(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::DecrementOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -803,7 +803,7 @@ public:
 
 class UnaryMinus : public ByteCode {
 public:
-    UnaryMinus(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    UnaryMinus(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::UnaryMinusOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -823,7 +823,7 @@ public:
 
 class UnaryNot : public ByteCode {
 public:
-    UnaryNot(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    UnaryNot(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::UnaryNotOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -843,7 +843,7 @@ public:
 
 class UnaryBitwiseNot : public ByteCode {
 public:
-    UnaryBitwiseNot(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex)
+    UnaryBitwiseNot(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex)
         : ByteCode(Opcode::UnaryBitwiseNotOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -863,7 +863,7 @@ public:
 
 class UnaryTypeof : public ByteCode {
 public:
-    UnaryTypeof(const ByteCodeLOC& loc, const size_t& srcIndex, const size_t& dstIndex, AtomicString name)
+    UnaryTypeof(const ByteCodeLOC& loc, const size_t srcIndex, const size_t dstIndex, AtomicString name)
         : ByteCode(Opcode::UnaryTypeofOpcode, loc)
         , m_srcIndex(srcIndex)
         , m_dstIndex(dstIndex)
@@ -885,7 +885,7 @@ public:
 
 class UnaryDelete : public ByteCode {
 public:
-    UnaryDelete(const ByteCodeLOC& loc, const size_t& srcIndex0, const size_t& srcIndex1, const size_t& dstIndex, AtomicString name)
+    UnaryDelete(const ByteCodeLOC& loc, const size_t srcIndex0, const size_t srcIndex1, const size_t dstIndex, AtomicString name)
         : ByteCode(Opcode::UnaryDeleteOpcode, loc)
         , m_srcIndex0(srcIndex0)
         , m_srcIndex1(srcIndex1)
@@ -909,7 +909,7 @@ public:
 
 class TemplateOperation : public ByteCode {
 public:
-    TemplateOperation(const ByteCodeLOC& loc, const size_t& src0Index, const size_t& src1Index, const size_t& dstIndex)
+    TemplateOperation(const ByteCodeLOC& loc, const size_t src0Index, const size_t src1Index, const size_t dstIndex)
         : ByteCode(Opcode::TemplateOperationOpcode, loc)
         , m_src0Index(src0Index)
         , m_src1Index(src1Index)
@@ -966,7 +966,7 @@ public:
     {
     }
 
-    ControlFlowRecord(const ControlFlowReason& reason, const size_t& value, size_t count = 0, size_t outerLimitCount = SIZE_MAX)
+    ControlFlowRecord(const ControlFlowReason& reason, const size_t value, size_t count = 0, size_t outerLimitCount = SIZE_MAX)
         : m_reason(reason)
         , m_wordValue(value)
         , m_count(count)
@@ -994,7 +994,7 @@ public:
         return m_wordValue;
     }
 
-    void setWordValue(const size_t& value)
+    void setWordValue(const size_t value)
     {
         m_wordValue = value;
     }
@@ -1050,14 +1050,14 @@ COMPILE_ASSERT(sizeof(Jump) == sizeof(JumpComplexCase), "");
 
 class JumpIfTrue : public ByteCode {
 public:
-    JumpIfTrue(const ByteCodeLOC& loc, const size_t& registerIndex)
+    JumpIfTrue(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::JumpIfTrueOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_jumpPosition(SIZE_MAX)
     {
     }
 
-    JumpIfTrue(const ByteCodeLOC& loc, const size_t& registerIndex, size_t pos)
+    JumpIfTrue(const ByteCodeLOC& loc, const size_t registerIndex, size_t pos)
         : ByteCode(Opcode::JumpIfTrueOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_jumpPosition(pos)
@@ -1077,7 +1077,7 @@ public:
 
 class JumpIfFalse : public ByteCode {
 public:
-    JumpIfFalse(const ByteCodeLOC& loc, const size_t& registerIndex)
+    JumpIfFalse(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::JumpIfFalseOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_jumpPosition(SIZE_MAX)
@@ -1097,7 +1097,7 @@ public:
 
 class CallFunction : public ByteCode {
 public:
-    CallFunction(const ByteCodeLOC& loc, const size_t& calleeIndex, const size_t& argumentsStartIndex, const size_t& argumentCount, const size_t& resultIndex)
+    CallFunction(const ByteCodeLOC& loc, const size_t calleeIndex, const size_t argumentsStartIndex, const size_t argumentCount, const size_t resultIndex)
         : ByteCode(Opcode::CallFunctionOpcode, loc)
         , m_calleeIndex(calleeIndex)
         , m_argumentsStartIndex(argumentsStartIndex)
@@ -1120,7 +1120,7 @@ public:
 
 class CallFunctionWithReceiver : public ByteCode {
 public:
-    CallFunctionWithReceiver(const ByteCodeLOC& loc, const size_t& receiverIndex, const size_t& calleeIndex, const size_t& argumentsStartIndex, const size_t& argumentCount, const size_t& resultIndex)
+    CallFunctionWithReceiver(const ByteCodeLOC& loc, const size_t receiverIndex, const size_t calleeIndex, const size_t argumentsStartIndex, const size_t argumentCount, const size_t resultIndex)
         : ByteCode(Opcode::CallFunctionWithReceiverOpcode, loc)
         , m_receiverIndex(receiverIndex)
         , m_calleeIndex(calleeIndex)
@@ -1146,7 +1146,7 @@ public:
 
 class CallEvalFunction : public ByteCode {
 public:
-    CallEvalFunction(const ByteCodeLOC& loc, const size_t& evalIndex, const size_t& argumentsStartIndex, size_t argumentCount, const size_t& resultIndex, bool inWithScope)
+    CallEvalFunction(const ByteCodeLOC& loc, const size_t evalIndex, const size_t argumentsStartIndex, size_t argumentCount, const size_t resultIndex, bool inWithScope)
         : ByteCode(Opcode::CallEvalFunctionOpcode, loc)
         , m_evalIndex(evalIndex)
         , m_argumentsStartIndex(argumentsStartIndex)
@@ -1171,7 +1171,7 @@ public:
 
 class CallFunctionInWithScope : public ByteCode {
 public:
-    CallFunctionInWithScope(const ByteCodeLOC& loc, const AtomicString& calleeName, const size_t& argumentsStartIndex, size_t argumentCount, const size_t& resultIndex)
+    CallFunctionInWithScope(const ByteCodeLOC& loc, const AtomicString& calleeName, const size_t argumentsStartIndex, size_t argumentCount, const size_t resultIndex)
         : ByteCode(Opcode::CallFunctionInWithScopeOpcode, loc)
         , m_calleeName(calleeName)
         , m_argumentsStartIndex(argumentsStartIndex)
@@ -1195,7 +1195,7 @@ public:
 
 class NewOperation : public ByteCode {
 public:
-    NewOperation(const ByteCodeLOC& loc, const size_t& calleeIndex, const size_t& argumentsStartIndex, const size_t& argumentCount, const size_t& resultIndex)
+    NewOperation(const ByteCodeLOC& loc, const size_t calleeIndex, const size_t argumentsStartIndex, const size_t argumentCount, const size_t resultIndex)
         : ByteCode(Opcode::NewOperationOpcode, loc)
         , m_calleeIndex(calleeIndex)
         , m_argumentsStartIndex(argumentsStartIndex)
@@ -1232,7 +1232,7 @@ public:
 
 class ReturnFunctionWithValue : public ByteCode {
 public:
-    ReturnFunctionWithValue(const ByteCodeLOC& loc, const size_t& registerIndex)
+    ReturnFunctionWithValue(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::ReturnFunctionWithValueOpcode, loc)
         , m_registerIndex(registerIndex)
     {
@@ -1249,7 +1249,7 @@ public:
 
 class ReturnFunctionSlowCase : public ByteCode {
 public:
-    ReturnFunctionSlowCase(const ByteCodeLOC& loc, const size_t& registerIndex)
+    ReturnFunctionSlowCase(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::ReturnFunctionSlowCaseOpcode, loc)
         , m_registerIndex(registerIndex)
     {
@@ -1320,7 +1320,7 @@ public:
 
 class ThrowOperation : public ByteCode {
 public:
-    ThrowOperation(const ByteCodeLOC& loc, const size_t& registerIndex)
+    ThrowOperation(const ByteCodeLOC& loc, const size_t registerIndex)
         : ByteCode(Opcode::ThrowOperationOpcode, loc)
         , m_registerIndex(registerIndex)
     {
@@ -1430,7 +1430,7 @@ public:
 
 class LoadRegexp : public ByteCode {
 public:
-    LoadRegexp(const ByteCodeLOC& loc, const size_t& registerIndex, String* body, String* opt)
+    LoadRegexp(const ByteCodeLOC& loc, const size_t registerIndex, String* body, String* opt)
         : ByteCode(Opcode::LoadRegexpOpcode, loc)
         , m_registerIndex(registerIndex)
         , m_body(body)

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -42,7 +42,7 @@ namespace Escargot {
 
 #define ADD_PROGRAM_COUNTER(CodeType) programCounter += sizeof(CodeType);
 
-ALWAYS_INLINE size_t jumpTo(char* codeBuffer, const size_t& jumpPosition)
+ALWAYS_INLINE size_t jumpTo(char* codeBuffer, const size_t jumpPosition)
 {
     return (size_t)&codeBuffer[jumpPosition];
 }

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -264,7 +264,7 @@ void ArrayObject::convertIntoNonFastMode(ExecutionState& state)
     m_fastModeData.clear();
 }
 
-bool ArrayObject::setArrayLength(ExecutionState& state, const uint64_t& newLength)
+bool ArrayObject::setArrayLength(ExecutionState& state, const uint64_t newLength)
 {
     if (UNLIKELY(isFastModeArray() && (newLength > ESCARGOT_ARRAY_NON_FASTMODE_MIN_SIZE))) {
         uint32_t orgLength = getArrayLength(state);

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -104,7 +104,7 @@ private:
         return m_values[ESCARGOT_OBJECT_BUILTIN_PROPERTY_NUMBER].toUint32(state);
     }
 
-    bool setArrayLength(ExecutionState& state, const uint64_t& newLength);
+    bool setArrayLength(ExecutionState& state, const uint64_t newLength);
     bool defineArrayLengthProperty(ExecutionState& state, const ObjectPropertyDescriptor& desc);
     void convertIntoNonFastMode(ExecutionState& state);
 

--- a/src/runtime/EnvironmentRecord.cpp
+++ b/src/runtime/EnvironmentRecord.cpp
@@ -71,7 +71,7 @@ void GlobalEnvironmentRecord::setMutableBinding(ExecutionState& state, const Ato
     m_globalObject->setThrowsExceptionWhenStrictMode(state, name, V, m_globalObject);
 }
 
-void GlobalEnvironmentRecord::setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& V)
+void GlobalEnvironmentRecord::setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& V)
 {
     m_globalObject->setThrowsExceptionWhenStrictMode(state, name, V, m_globalObject);
 }
@@ -174,7 +174,7 @@ void DeclarativeEnvironmentRecordNotIndexed::setMutableBinding(ExecutionState& s
     ASSERT_NOT_REACHED();
 }
 
-void DeclarativeEnvironmentRecordNotIndexed::setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v)
+void DeclarativeEnvironmentRecordNotIndexed::setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v)
 {
     m_heapStorage[idx] = v;
 }
@@ -232,7 +232,7 @@ void FunctionEnvironmentRecordNotIndexed::setMutableBinding(ExecutionState& stat
     ASSERT_NOT_REACHED();
 }
 
-void FunctionEnvironmentRecordNotIndexed::setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v)
+void FunctionEnvironmentRecordNotIndexed::setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v)
 {
     if (UNLIKELY(!m_recordVector[idx].m_isMutable)) {
         if (state.inStrictMode())

--- a/src/runtime/EnvironmentRecord.h
+++ b/src/runtime/EnvironmentRecord.h
@@ -86,7 +86,7 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v)
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v)
     {
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -117,7 +117,7 @@ public:
         return GetBindingValueResult();
     }
 
-    virtual Value getBindingValue(ExecutionState& state, const size_t& idx)
+    virtual Value getBindingValue(ExecutionState& state, const size_t idx)
     {
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -227,7 +227,7 @@ public:
         }
     }
 
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v)
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v)
     {
         m_bindingObject->setThrowsExceptionWhenStrictMode(state, ObjectPropertyName(name), v, m_bindingObject);
     }
@@ -264,7 +264,7 @@ public:
     virtual void createBinding(ExecutionState& state, const AtomicString& name, bool canDelete = false, bool isMutable = true);
     virtual GetBindingValueResult getBindingValue(ExecutionState& state, const AtomicString& name);
     virtual void setMutableBinding(ExecutionState& state, const AtomicString& name, const Value& V);
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v);
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v);
     virtual bool deleteBinding(ExecutionState& state, const AtomicString& name);
     virtual BindingSlot hasBinding(ExecutionState& state, const AtomicString& atomicName);
     virtual void initializeBinding(ExecutionState& state, const AtomicString& name, const Value& V);
@@ -312,7 +312,7 @@ public:
         return reinterpret_cast<FunctionEnvironmentRecord*>(this);
     }
 
-    virtual void setHeapValueByIndex(const size_t& idx, const Value& v)
+    virtual void setHeapValueByIndex(const size_t idx, const Value& v)
     {
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -366,7 +366,7 @@ public:
     virtual void createBinding(ExecutionState& state, const AtomicString& name, bool canDelete = false, bool isMutable = true);
     virtual GetBindingValueResult getBindingValue(ExecutionState& state, const AtomicString& name);
     virtual void setMutableBinding(ExecutionState& state, const AtomicString& name, const Value& V);
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v);
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v);
 
     virtual bool deleteBinding(ExecutionState& state, const AtomicString& name)
     {
@@ -426,7 +426,7 @@ public:
         return false;
     }
 
-    virtual Value getHeapValueByIndex(const size_t& idx)
+    virtual Value getHeapValueByIndex(const size_t idx)
     {
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -478,12 +478,12 @@ public:
         return true;
     }
 
-    virtual void setHeapValueByIndex(const size_t& idx, const Value& v)
+    virtual void setHeapValueByIndex(const size_t idx, const Value& v)
     {
         m_heapStorage[idx] = v;
     }
 
-    virtual Value getHeapValueByIndex(const size_t& idx)
+    virtual Value getHeapValueByIndex(const size_t idx)
     {
         return m_heapStorage[idx];
     }
@@ -512,7 +512,7 @@ public:
         return BindingSlot(this, SIZE_MAX);
     }
 
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v)
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v)
     {
         m_heapStorage[idx] = v;
     }
@@ -557,12 +557,12 @@ public:
         return true;
     }
 
-    virtual void setHeapValueByIndex(const size_t& idx, const Value& v)
+    virtual void setHeapValueByIndex(const size_t idx, const Value& v)
     {
         m_heapStorage[idx] = v;
     }
 
-    virtual Value getHeapValueByIndex(const size_t& idx)
+    virtual Value getHeapValueByIndex(const size_t idx)
     {
         return m_heapStorage[idx];
     }
@@ -603,7 +603,7 @@ public:
     virtual void createBinding(ExecutionState& state, const AtomicString& name, bool canDelete = false, bool isMutable = true);
     virtual GetBindingValueResult getBindingValue(ExecutionState& state, const AtomicString& name);
     virtual void setMutableBinding(ExecutionState& state, const AtomicString& name, const Value& V);
-    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t& idx, const AtomicString& name, const Value& v);
+    virtual void setMutableBindingByIndex(ExecutionState& state, const size_t idx, const AtomicString& name, const Value& v);
 
     virtual size_t argc()
     {

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -237,7 +237,7 @@ NEVER_INLINE void FunctionObject::generateBytecodeBlock(ExecutionState& state)
     currentCodeSizeTotal += m_codeBlock->m_byteCodeBlock->memoryAllocatedSize();
 }
 
-Value FunctionObject::callSlowCase(ExecutionState& state, const Value& callee, const Value& receiver, const size_t& argc, Value* argv, bool isNewExpression)
+Value FunctionObject::callSlowCase(ExecutionState& state, const Value& callee, const Value& receiver, const size_t argc, Value* argv, bool isNewExpression)
 {
     if (LIKELY(callee.isObject())) {
         if (LIKELY(callee.asPointerValue()->isFunctionObject()))
@@ -251,7 +251,7 @@ Value FunctionObject::callSlowCase(ExecutionState& state, const Value& callee, c
     return Value();
 }
 
-Object* FunctionObject::newInstance(ExecutionState& state, const size_t& argc, Value* argv)
+Object* FunctionObject::newInstance(ExecutionState& state, const size_t argc, Value* argv)
 {
     CodeBlock* cb = codeBlock();
     FunctionObject* targetFunction = this;
@@ -283,7 +283,7 @@ Object* FunctionObject::newInstance(ExecutionState& state, const size_t& argc, V
         return receiver;
 }
 
-Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSrc, const size_t& argc, Value* argv, bool isNewExpression)
+Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSrc, const size_t argc, Value* argv, bool isNewExpression)
 {
     volatile int sp;
     size_t currentStackBase = (size_t)&sp;

--- a/src/runtime/FunctionObject.h
+++ b/src/runtime/FunctionObject.h
@@ -92,14 +92,14 @@ public:
         return m_codeBlock;
     }
 
-    Value call(ExecutionState& state, const Value& receiver, const size_t& argc, Value* argv)
+    Value call(ExecutionState& state, const Value& receiver, const size_t argc, Value* argv)
     {
         return processCall(state, receiver, argc, argv, false);
     }
     // ECMAScript new operation
-    Object* newInstance(ExecutionState& state, const size_t& argc, Value* argv);
+    Object* newInstance(ExecutionState& state, const size_t argc, Value* argv);
 
-    ALWAYS_INLINE static Value call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t& argc, Value* argv)
+    ALWAYS_INLINE static Value call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t argc, Value* argv)
     {
         if (LIKELY(callee.isObject() && callee.asPointerValue()->hasTag(g_functionObjectTag))) {
             return callee.asFunction()->processCall(state, receiver, argc, argv, false);
@@ -135,8 +135,8 @@ private:
         return true;
     }
 
-    Value processCall(ExecutionState& state, const Value& receiver, const size_t& argc, Value* argv, bool isNewExpression);
-    static Value callSlowCase(ExecutionState& state, const Value& callee, const Value& receiver, const size_t& argc, Value* argv, bool isNewExpression);
+    Value processCall(ExecutionState& state, const Value& receiver, const size_t argc, Value* argv, bool isNewExpression);
+    static Value callSlowCase(ExecutionState& state, const Value& callee, const Value& receiver, const size_t argc, Value* argv, bool isNewExpression);
     void generateArgumentsObject(ExecutionState& state, FunctionEnvironmentRecord* fnRecord, Value* stackStorage);
     void generateBytecodeBlock(ExecutionState& state);
     CodeBlock* m_codeBlock;

--- a/src/runtime/GlobalObjectBuiltinPromise.cpp
+++ b/src/runtime/GlobalObjectBuiltinPromise.cpp
@@ -30,7 +30,7 @@
 
 namespace Escargot {
 
-static SandBox::SandBoxResult tryCallMethodAndCatchError(ExecutionState& state, ObjectPropertyName name, Value receiver, Value arguments[], const size_t& argumentCount, bool isNewExpression)
+static SandBox::SandBoxResult tryCallMethodAndCatchError(ExecutionState& state, ObjectPropertyName name, Value receiver, Value arguments[], const size_t argumentCount, bool isNewExpression)
 {
     SandBox sb(state.context());
     return sb.run([&]() -> Value {

--- a/src/runtime/ProxyObject.cpp
+++ b/src/runtime/ProxyObject.cpp
@@ -774,7 +774,7 @@ bool ProxyObject::set(ExecutionState& state, const ObjectPropertyName& propertyN
 }
 
 // https://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
-Value ProxyObject::call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t& argc, Value* argv)
+Value ProxyObject::call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t argc, Value* argv)
 {
     auto strings = &state.context()->staticStrings();
     // 2. If handler is null, throw a TypeError exception.
@@ -816,7 +816,7 @@ Value ProxyObject::call(ExecutionState& state, const Value& callee, const Value&
 
 // FIXME newTarget is missing [[Construct]] ( argumentsList, newTarget)
 // https://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
-Object* ProxyObject::construct(ExecutionState& state, const size_t& argc, Value* argv)
+Object* ProxyObject::construct(ExecutionState& state, const size_t argc, Value* argv)
 {
     auto strings = &state.context()->staticStrings();
     // 2. If handler is null, throw a TypeError exception.

--- a/src/runtime/ProxyObject.h
+++ b/src/runtime/ProxyObject.h
@@ -109,9 +109,9 @@ public:
 
     virtual bool isExtensible(ExecutionState&) override;
 
-    Value call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t& argc, Value* argv);
+    Value call(ExecutionState& state, const Value& callee, const Value& receiver, const size_t argc, Value* argv);
 
-    Object* construct(ExecutionState& state, const size_t& argc, Value* argv);
+    Object* construct(ExecutionState& state, const size_t argc, Value* argv);
 
     void setTarget(Object* target)
     {

--- a/src/runtime/RopeString.h
+++ b/src/runtime/RopeString.h
@@ -48,7 +48,7 @@ public:
     {
         return m_contentLength;
     }
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return normalString()->charAt(idx);
     }

--- a/src/runtime/SmallValue.h
+++ b/src/runtime/SmallValue.h
@@ -156,7 +156,7 @@ public:
         m_data.payload = from.m_data.payload;
     }
 
-    explicit SmallValue(const uint32_t& from)
+    explicit SmallValue(const uint32_t from)
     {
         if (LIKELY(SmallValueImpl::PlatformSmiTagging::IsValidSmi(from))) {
             m_data.payload = SmallValueImpl::PlatformSmiTagging::IntToSmi(from);

--- a/src/runtime/String.cpp
+++ b/src/runtime/String.cpp
@@ -60,7 +60,7 @@ size_t g_utf16StringTag;
 size_t g_ropeStringTag;
 size_t g_stringViewTag;
 
-bool isAllASCII(const char* buf, const size_t& len)
+bool isAllASCII(const char* buf, const size_t len)
 {
     for (unsigned i = 0; i < len; i++) {
         if ((buf[i] & 0x80) != 0) {
@@ -70,7 +70,7 @@ bool isAllASCII(const char* buf, const size_t& len)
     return true;
 }
 
-bool isAllASCII(const char16_t* buf, const size_t& len)
+bool isAllASCII(const char16_t* buf, const size_t len)
 {
     for (unsigned i = 0; i < len; i++) {
         if (buf[i] >= 128) {
@@ -80,7 +80,7 @@ bool isAllASCII(const char16_t* buf, const size_t& len)
     return true;
 }
 
-bool isAllLatin1(const char16_t* buf, const size_t& len)
+bool isAllLatin1(const char16_t* buf, const size_t len)
 {
     for (unsigned i = 0; i < len; i++) {
         if (buf[i] >= 256) {
@@ -156,7 +156,7 @@ char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen)
     return ch - offsetsFromUTF8[length - 1];
 }
 
-UTF16StringData utf8StringToUTF16String(const char* buf, const size_t& len)
+UTF16StringData utf8StringToUTF16String(const char* buf, const size_t len)
 {
     UTF16StringDataNonGCStd str;
     const char* source = buf;
@@ -185,7 +185,7 @@ UTF16StringData utf8StringToUTF16String(const char* buf, const size_t& len)
     return UTF16StringData(str.data(), str.length());
 }
 
-ASCIIStringData utf16StringToASCIIString(const char16_t* buf, const size_t& len)
+ASCIIStringData utf16StringToASCIIString(const char16_t* buf, const size_t len)
 {
     ASCIIStringData str;
     str.resizeWithUninitializedValues(len);

--- a/src/runtime/String.h
+++ b/src/runtime/String.h
@@ -41,14 +41,14 @@ typedef std::basic_string<char, std::char_traits<char>> UTF8StringDataNonGCStd;
 typedef std::basic_string<char16_t, std::char_traits<char16_t>> UTF16StringDataNonGCStd;
 typedef std::basic_string<char32_t, std::char_traits<char32_t>> UTF32StringDataNonGCStd;
 
-bool isAllASCII(const char* buf, const size_t& len);
-bool isAllASCII(const char16_t* buf, const size_t& len);
-bool isAllLatin1(const char16_t* buf, const size_t& len);
+bool isAllASCII(const char* buf, const size_t len);
+bool isAllASCII(const char16_t* buf, const size_t len);
+bool isAllLatin1(const char16_t* buf, const size_t len);
 bool isIndexString(String* str);
 char32_t readUTF8Sequence(const char*& sequence, bool& valid, int& charlen);
-UTF16StringData utf8StringToUTF16String(const char* buf, const size_t& len);
-UTF8StringData utf16StringToUTF8String(const char16_t* buf, const size_t& len);
-ASCIIStringData utf16StringToASCIIString(const char16_t* buf, const size_t& len);
+UTF16StringData utf8StringToUTF16String(const char* buf, const size_t len);
+UTF8StringData utf16StringToUTF8String(const char16_t* buf, const size_t len);
+ASCIIStringData utf16StringToASCIIString(const char16_t* buf, const size_t len);
 ASCIIStringData dtoa(double number);
 size_t utf32ToUtf8(char32_t uc, char* UTF8);
 // these functions only care ascii range(0~127)
@@ -191,8 +191,8 @@ public:
     static String* fromUTF8(const char* src, size_t len);
 
     virtual size_t length() const = 0;
-    virtual char16_t charAt(const size_t& idx) const = 0;
-    char16_t operator[](const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const = 0;
+    char16_t operator[](const size_t idx) const
     {
         return charAt(idx);
     }
@@ -314,12 +314,12 @@ protected:
     static int stringCompare(size_t l1, size_t l2, const String* c1, const String* c2);
 
     template <typename T>
-    static ALWAYS_INLINE bool stringEqual(const T* s, const T* s1, const size_t& len)
+    static ALWAYS_INLINE bool stringEqual(const T* s, const T* s1, const size_t len)
     {
         return memcmp(s, s1, sizeof(T) * len) == 0;
     }
 
-    static ALWAYS_INLINE bool stringEqual(const char16_t* s, const LChar* s1, const size_t& len)
+    static ALWAYS_INLINE bool stringEqual(const char16_t* s, const LChar* s1, const size_t len)
     {
         for (size_t i = 0; i < len; i++) {
             if (s[i] != s1[i]) {
@@ -394,7 +394,7 @@ public:
         initBufferAccessData(stringData);
     }
 
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return m_bufferAccessData.uncheckedCharAtFor8Bit(idx);
     }
@@ -489,7 +489,7 @@ public:
         m_bufferAccessData.buffer = stringData.takeBuffer();
     }
 
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return m_bufferAccessData.uncheckedCharAtFor8Bit(idx);
     }
@@ -560,7 +560,7 @@ public:
         m_bufferAccessData.buffer = stringData.takeBuffer();
     }
 
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return m_bufferAccessData.uncheckedCharAtFor16Bit(idx);
     }

--- a/src/runtime/StringView.h
+++ b/src/runtime/StringView.h
@@ -26,7 +26,7 @@ namespace Escargot {
 
 class StringView : public String {
 public:
-    ALWAYS_INLINE StringView(String* str, const size_t& s, const size_t& e)
+    ALWAYS_INLINE StringView(String* str, const size_t s, const size_t e)
         : String()
         , m_string(str)
     {
@@ -35,7 +35,7 @@ public:
         initBufferAccessData(str->bufferAccessData(), s, e);
     }
 
-    ALWAYS_INLINE StringView(const StringView& str, const size_t& s, const size_t& e)
+    ALWAYS_INLINE StringView(const StringView& str, const size_t s, const size_t e)
         : String()
         , m_string(str.string())
     {
@@ -49,7 +49,7 @@ public:
         initBufferAccessData(String::emptyString->bufferAccessData(), 0, 0);
     }
 
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return bufferAccessData().charAt(idx);
     }
@@ -124,7 +124,7 @@ public:
         return (const char16_t*)m_bufferAccessData.buffer;
     }
 
-    char16_t bufferedCharAt(const size_t& idx) const
+    char16_t bufferedCharAt(const size_t idx) const
     {
         if (m_bufferAccessData.has8BitContent) {
             return ((const LChar*)m_bufferAccessData.buffer)[idx];
@@ -182,7 +182,7 @@ public:
         m_bufferAccessData = str.bufferAccessData();
     }
 
-    virtual char16_t charAt(const size_t& idx) const
+    virtual char16_t charAt(const size_t idx) const
     {
         return bufferAccessData().charAt(idx);
     }
@@ -257,7 +257,7 @@ public:
         return (const char16_t*)m_bufferAccessData.buffer;
     }
 
-    char16_t bufferedCharAt(const size_t& idx) const
+    char16_t bufferedCharAt(const size_t idx) const
     {
         if (m_bufferAccessData.has8BitContent) {
             return ((const LChar*)m_bufferAccessData.buffer)[idx];

--- a/src/util/BasicString.h
+++ b/src/util/BasicString.h
@@ -189,13 +189,13 @@ public:
         erase(m_size - 1);
     }
 
-    T& operator[](const size_t& idx)
+    T& operator[](const size_t idx)
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];
     }
 
-    const T& operator[](const size_t& idx) const
+    const T& operator[](const size_t idx) const
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];

--- a/src/util/TightVector.h
+++ b/src/util/TightVector.h
@@ -169,13 +169,13 @@ public:
         erase(m_size - 1);
     }
 
-    T& operator[](const size_t& idx)
+    T& operator[](const size_t idx)
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];
     }
 
-    const T& operator[](const size_t& idx) const
+    const T& operator[](const size_t idx) const
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];
@@ -292,12 +292,12 @@ public:
         pushBack(val, newSize);
     }
 
-    T& operator[](const size_t& idx)
+    T& operator[](const size_t idx)
     {
         return m_buffer[idx];
     }
 
-    const T& operator[](const size_t& idx) const
+    const T& operator[](const size_t idx) const
     {
         return m_buffer[idx];
     }

--- a/src/util/Vector.h
+++ b/src/util/Vector.h
@@ -214,13 +214,13 @@ public:
         erase(m_size - 1);
     }
 
-    T& operator[](const size_t& idx)
+    T& operator[](const size_t idx)
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];
     }
 
-    const T& operator[](const size_t& idx) const
+    const T& operator[](const size_t idx) const
     {
         ASSERT(idx < m_size);
         return m_buffer[idx];
@@ -366,12 +366,12 @@ public:
         return m_capacity;
     }
 
-    T& operator[](const size_t& idx)
+    T& operator[](const size_t idx)
     {
         return m_buffer[idx];
     }
 
-    const T& operator[](const size_t& idx) const
+    const T& operator[](const size_t idx) const
     {
         return m_buffer[idx];
     }


### PR DESCRIPTION
Passing primitive values by value is faster than passing by reference.

Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu