### PR TITLE
Fix RegExp.prototype.toString() function

### DIFF
--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -110,6 +110,11 @@ public:
         return m_source;
     }
 
+    String* optionString()
+    {
+        return m_optionString;
+    }
+
     Option option()
     {
         return m_option;
@@ -163,10 +168,11 @@ private:
 
     static RegExpCacheEntry& getCacheEntryAndCompileIfNeeded(ExecutionState& state, String* source, const Option& option);
 
-    static Option parseOption(ExecutionState& state, const String* optionString);
+    void parseOption(ExecutionState& state, const String* optionString);
 
 
     String* m_source;
+    String* m_optionString;
     Option m_option;
     JSC::Yarr::YarrPattern* m_yarrPattern;
     JSC::Yarr::BytecodePattern* m_bytecodePattern;

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -162,6 +162,7 @@ namespace Escargot {
     F(string)                     \
     F(object)                     \
     F(function)                   \
+    F(flags)                      \
     F(RegExp)                     \
     F(source)                     \
     F(lastIndex)                  \

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -111,6 +111,14 @@ Value VMInstance::regexpSourceNativeGetter(ExecutionState& state, Object* self, 
 static ObjectPropertyNativeGetterSetterData regexpSourceGetterData(
     false, false, false, &VMInstance::regexpSourceNativeGetter, &VMInstance::undefinedNativeSetter);
 
+Value VMInstance::regexpFlagsNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
+{
+    ASSERT(self->isRegExpObject());
+    return Value(self->asRegExpObject()->optionString());
+}
+static ObjectPropertyNativeGetterSetterData regexpFlagsGetterData(
+    false, false, true, &VMInstance::regexpFlagsNativeGetter, &VMInstance::undefinedNativeSetter);
+
 Value VMInstance::regexpGlobalNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
     ASSERT(self->isRegExpObject());
@@ -266,6 +274,8 @@ VMInstance::VMInstance(const char* locale, const char* timezone)
     // TODO(ES6): Below RegExp data properties is changed to accessor properties of RegExp.prototype in ES6.
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.source,
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpSourceGetterData));
+    m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.flags,
+                                                                                       ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpFlagsGetterData));
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.global,
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpGlobalGetterData));
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.ignoreCase,

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -150,10 +150,11 @@ public:
     static bool stringLengthNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData);
 
     // regexp
-    // [lastIndex, source, global, ignoreCase, multiline]
+    // [lastIndex, source, flags, global, ignoreCase, multiline]
     static bool regexpLastIndexNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData);
     static Value regexpLastIndexNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpSourceNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
+    static Value regexpFlagsNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpGlobalNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpIgnoreCaseNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);
     static Value regexpMultilineNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea);

--- a/test/regression-tests/issue-117.js
+++ b/test/regression-tests/issue-117.js
@@ -1,0 +1,38 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var fake =
+    {
+      get source() {
+        return {
+          toString: function() {
+            return "pattern";
+          }
+        };
+      },
+      get flags() {
+        return {
+          toString: function() {
+            return "flags";
+          }
+        };
+      }
+    }
+
+assert("/pattern/flags" == RegExp.prototype.toString.call(fake));


### PR DESCRIPTION
The function had a wrong behaviour expecting `this` value to be a RegExp Object.
However as the standard says `this` value should be an Object, and its `source` and `pattern` values' `toString()`s should be returned in a form of `/<source>/<flags>`.
Fixes #117

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>