### PR TITLE
Fix String.prototype.match() function to correctly change `lastValue`.

### DIFF
--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -192,7 +192,6 @@ static Value builtinStringMatch(ExecutionState& state, Value thisValue, size_t a
         regexp = new RegExpObject(state, argument.isUndefined() ? String::emptyString : argument.toString(state), String::emptyString);
     }
 
-    (void)regexp->lastIndex().toInteger(state);
     bool isGlobal = regexp->option() & RegExpObject::Option::Global;
     if (isGlobal) {
         regexp->setLastIndex(state, Value(0));

--- a/test/regression-tests/issue-119.js
+++ b/test/regression-tests/issue-119.js
@@ -1,0 +1,26 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Tests that lastIndex of a global RegExp is overwritten as per
+// ECMA-262 6.0 21.2.5.8 step 10.c.
+
+var global = /./g;
+global.lastIndex = { valueOf: function() { assert(false); } };
+assert("X" === "x".replace(global, function(a) { return "X"; }));
+assert(0 === global.lastIndex);


### PR DESCRIPTION
Fixes #119

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>