### PR TITLE
Minor update of NullablePtr

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -111,7 +111,6 @@ DEFINE_CAST(Float64ArrayObject);
 
 #undef DEFINE_CAST
 
-
 inline ValueRef* toRef(const Value& v)
 {
     ASSERT(!v.isEmpty());
@@ -1499,6 +1498,12 @@ ValueRef* ValueRef::create(long long value)
 ValueRef* ValueRef::create(unsigned long long value)
 {
     return reinterpret_cast<ValueRef*>(SmallValue(Value(value)).payload());
+}
+
+ValueRef* ValueRef::create(ValueRef* value)
+{
+    ASSERT(value);
+    return reinterpret_cast<ValueRef*>(value);
 }
 
 ValueRef* ValueRef::createNull()

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -79,7 +79,7 @@ public:
 };
 
 template <typename T>
-struct NullablePtr {
+struct EXPORT NullablePtr {
 public:
     NullablePtr()
         : m_value(nullptr)
@@ -93,13 +93,11 @@ public:
 
     T* getValue()
     {
-        ASSERT(!!m_value);
         return m_value;
     }
 
     const T* getValue() const
     {
-        ASSERT(!!m_value);
         return m_value;
     }
 
@@ -279,8 +277,8 @@ public:
     GlobalObjectRef* globalObject();
     VMInstanceRef* vmInstance();
 
-    typedef ValueRef* (*VirtualIdentifierCallback)(ExecutionStateRef* state, ValueRef* name);
-    typedef ValueRef* (*SecurityPolicyCheckCallback)(ExecutionStateRef* state, bool isEval);
+    typedef NullablePtr<ValueRef> (*VirtualIdentifierCallback)(ExecutionStateRef* state, ValueRef* name);
+    typedef NullablePtr<ValueRef> (*SecurityPolicyCheckCallback)(ExecutionStateRef* state, bool isEval);
 
     // this is not compatible with ECMAScript
     // but this callback is needed for browser-implementation
@@ -332,11 +330,8 @@ public:
     static ValueRef* create(unsigned long);
     static ValueRef* create(long long);
     static ValueRef* create(unsigned long long);
+    static ValueRef* create(ValueRef* value);
     static ValueRef* create(PointerValueRef* value)
-    {
-        return reinterpret_cast<ValueRef*>(value);
-    }
-    static ValueRef* create(ValueRef* value)
     {
         return reinterpret_cast<ValueRef*>(value);
     }


### PR DESCRIPTION
* fix build error to sync with lightweight-web-engine

NOTE
`ASSERT` statements in EscargotPublic.h are removed due to build dependency problem in the lightweight-web-engine. But guard codes in `toImpl` and `toRef` is still enough to check the dereferencing of null pointer.
NullablePtr is also added for some callback functions.

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>