### PR TITLE
Update Iterator Operations

### DIFF
--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -22,6 +22,7 @@
 #include "Context.h"
 #include "VMInstance.h"
 #include "SetObject.h"
+#include "IteratorOperations.h"
 #include "ToStringRecursionPreventer.h"
 
 namespace Escargot {
@@ -44,10 +45,8 @@ Value builtinSetConstructor(ExecutionState& state, Value thisValue, size_t argc,
     }
     // If iterable is either undefined or null, let iter be undefined.
     Value adder;
-    Object* iter = nullptr;
-    if (iterable.isUndefinedOrNull()) {
-        iterable = Value();
-    } else {
+    Value iter;
+    if (!iterable.isUndefinedOrNull()) {
         // Else,
         // Let adder be ? Get(set, "add").
         adder = set->Object::get(state, ObjectPropertyName(state.context()->staticStrings().add)).value(state, set);
@@ -56,27 +55,23 @@ Value builtinSetConstructor(ExecutionState& state, Value thisValue, size_t argc,
             ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, errorMessage_Call_NotFunction);
         }
         // Let iter be ? GetIterator(iterable).
-        iterable = iterable.toObject(state);
-        iter = iterable.asObject()->iterator(state);
-        if (iter == nullptr) {
-            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "object is not iterable");
-        }
+        iter = getIterator(state, iterable);
     }
     // If iter is undefined, return Set.
-    if (!iter) {
+    if (iter.isUndefined()) {
         return set;
     }
 
     // Repeat
     while (true) {
         // Let next be ? IteratorStep(iter).
-        auto next = iter->iteratorNext(state);
+        Value next = iteratorStep(state, iter);
         // If next is false, return set.
-        if (next.second) {
+        if (next.isFalse()) {
             return set;
         }
         // Let nextValue be ? IteratorValue(next).
-        Value nextValue = next.first;
+        Value nextValue = iteratorValue(state, next);
 
         // Let status be Call(adder, set, « nextValue.[[Value]] »).
         // TODO If status is an abrupt completion, return ? IteratorClose(iter, status).

--- a/src/runtime/GlobalObjectBuiltinWeakMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinWeakMap.cpp
@@ -23,6 +23,7 @@
 #include "VMInstance.h"
 #include "WeakMapObject.h"
 #include "IteratorObject.h"
+#include "IteratorOperations.h"
 #include "ToStringRecursionPreventer.h"
 
 namespace Escargot {
@@ -43,10 +44,8 @@ Value builtinWeakMapConstructor(ExecutionState& state, Value thisValue, size_t a
     }
     // If iterable is either undefined or null, let iter be undefined.
     Value adder;
-    Object* iter = nullptr;
-    if (iterable.isUndefinedOrNull()) {
-        iterable = Value();
-    } else {
+    Value iter;
+    if (!iterable.isUndefinedOrNull()) {
         // Else,
         // Let adder be ? Get(map, "set").
         adder = map->Object::get(state, ObjectPropertyName(state.context()->staticStrings().set)).value(state, map);
@@ -55,27 +54,23 @@ Value builtinWeakMapConstructor(ExecutionState& state, Value thisValue, size_t a
             ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, errorMessage_Call_NotFunction);
         }
         // Let iter be ? GetIterator(iterable).
-        iterable = iterable.toObject(state);
-        iter = iterable.asObject()->iterator(state);
-        if (iter == nullptr) {
-            ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "object is not iterable");
-        }
+        iter = getIterator(state, iterable);
     }
     // If iter is undefined, return map.
-    if (!iter) {
+    if (iter.isUndefined()) {
         return map;
     }
 
     // Repeat
     while (true) {
         // Let next be ? IteratorStep(iter).
-        auto next = iter->iteratorNext(state);
+        Value next = iteratorStep(state, iter);
         // If next is false(done is true), return map.
-        if (next.second) {
+        if (next.isFalse()) {
             return map;
         }
         // Let nextItem be ? IteratorValue(next).
-        Value nextItem = next.first;
+        Value nextItem = iteratorValue(state, next);
 
         // If Type(nextItem) is not Object, then
         if (!nextItem.isObject()) {

--- a/src/runtime/IteratorOperations.cpp
+++ b/src/runtime/IteratorOperations.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#include "Escargot.h"
+#include "IteratorOperations.h"
+#include "runtime/Context.h"
+#include "runtime/VMInstance.h"
+#include "runtime/Object.h"
+#include "runtime/FunctionObject.h"
+#include "runtime/ErrorObject.h"
+
+namespace Escargot {
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-getiterator
+Value getIterator(ExecutionState& state, const Value& obj, const Value& method)
+{
+    Object* object = obj.toObject(state);
+    Value func = method;
+    if (method.isEmpty()) {
+        func = object->getMethod(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().iterator));
+    }
+
+    Value iterator = FunctionObject::call(state, func, object, 0, nullptr);
+    if (!iterator.isObject()) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "result is not an object");
+    }
+
+    return iterator;
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-iteratornext
+Value iteratorNext(ExecutionState& state, const Value& iterator, const Value& value)
+{
+    Object* obj = iterator.toObject(state);
+    Value func = obj->get(state, ObjectPropertyName(state.context()->staticStrings().next)).value(state, obj);
+    Value result;
+
+    if (value.isEmpty()) {
+        result = FunctionObject::call(state, func, iterator, 0, nullptr);
+    } else {
+        Value argumentList[] = { value };
+        result = FunctionObject::call(state, func, iterator, 1, argumentList);
+    }
+
+    if (!result.isObject()) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "result is not an object");
+    }
+    return result;
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-iteratorcomplete
+bool iteratorComplete(ExecutionState& state, const Value& iterResult)
+{
+    ASSERT(iterResult.isObject());
+    Value result = iterResult.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().done)).value(state, iterResult.asObject());
+
+    return result.toBoolean(state);
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-iteratorvalue
+Value iteratorValue(ExecutionState& state, const Value& iterResult)
+{
+    ASSERT(iterResult.isObject());
+    Value result = iterResult.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().value)).value(state, iterResult.asObject());
+
+    return result;
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-iteratorstep
+Value iteratorStep(ExecutionState& state, const Value& iterator)
+{
+    Value result = iteratorNext(state, iterator, Value(Value::EmptyValue));
+    bool done = iteratorComplete(state, result);
+
+    return done ? Value(Value::False) : result;
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-iteratorclose
+void iteratorClose(ExecutionState& state, const Value& iterator)
+{
+    ASSERT(iterator.isObject());
+
+    Value returnFunction = iterator.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().stringReturn)).value(state, iterator.asObject());
+    if (returnFunction.isUndefined()) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "return function is undefined");
+    }
+
+    Value innerResult = FunctionObject::call(state, returnFunction, iterator, 0, nullptr);
+    if (!innerResult.isObject()) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "result is not an object");
+    }
+}
+
+// https://www.ecma-international.org/ecma-262/6.0/#sec-createiterresultobject
+Value createIterResultObject(ExecutionState& state, const Value& value, bool done)
+{
+    Object* obj = new Object(state);
+    obj->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().value), ObjectPropertyDescriptor(value, ObjectPropertyDescriptor::AllPresent));
+    obj->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().done), ObjectPropertyDescriptor(Value(done), ObjectPropertyDescriptor::AllPresent));
+
+    return obj;
+}
+}

--- a/src/runtime/IteratorOperations.h
+++ b/src/runtime/IteratorOperations.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-present Samsung Electronics Co., Ltd
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+
+#ifndef __EscargotIteratorOperations__
+#define __EscargotIteratorOperations__
+
+#include "runtime/Value.h"
+
+namespace Escargot {
+
+class ExecutionState;
+
+Value getIterator(ExecutionState& state, const Value& obj, const Value& method = Value(Value::EmptyValue));
+Value iteratorNext(ExecutionState& state, const Value& iterator, const Value& value = Value(Value::EmptyValue));
+bool iteratorComplete(ExecutionState& state, const Value& iterResult);
+Value iteratorValue(ExecutionState& state, const Value& iterResult);
+Value iteratorStep(ExecutionState& state, const Value& iterator);
+void iteratorClose(ExecutionState& state, const Value& iterator);
+Value createIterResultObject(ExecutionState& state, const Value& value, bool done);
+}
+#endif

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1091,31 +1091,4 @@ IteratorObject* Object::entries(ExecutionState& state)
 {
     return new ArrayIteratorObject(state, this, ArrayIteratorObject::TypeKeyValue);
 }
-
-Object* Object::iterator(ExecutionState& state)
-{
-    Value v = get(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().iterator)).value(state, this);
-    if (!v.isFunction()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "object is not iterable");
-    }
-    v = v.asFunction()->call(state, this, 0, nullptr);
-    if (!v.isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "object is not iterable");
-    }
-
-    return v.asObject();
-}
-
-std::pair<Value, bool> Object::iteratorNext(ExecutionState& state)
-{
-    Value mayBeFn = get(state, ObjectPropertyName(state.context()->staticStrings().next)).value(state, this);
-    Value returnValue = FunctionObject::call(state, mayBeFn, this, 0, nullptr);
-    if (!returnValue.isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "iterator next function returns illegal value");
-    }
-
-    Value done = returnValue.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().done)).value(state, returnValue);
-    Value value = returnValue.asObject()->get(state, ObjectPropertyName(state.context()->staticStrings().value)).value(state, returnValue);
-    return std::make_pair(value, done.toBoolean(state));
-}
 }

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -825,8 +825,6 @@ public:
     IteratorObject* values(ExecutionState& state);
     IteratorObject* keys(ExecutionState& state);
     IteratorObject* entries(ExecutionState& state);
-    Object* iterator(ExecutionState& state);
-    std::pair<Value, bool> iteratorNext(ExecutionState& state); // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-iteratornext
 
 protected:
     Object(ExecutionState& state, size_t defaultSpace, bool initPlainArea);


### PR DESCRIPTION
* implement getIterator, iteratorNext, iteratorComplete, iteratorValue, iteratorStep, iteratorClose, createIterResultObject method
* fix to correctly use iterator operations based on the ES2015 spec

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>