### PR TITLE
Update NullablePtr implementation to include assert statement

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -111,6 +111,22 @@ DEFINE_CAST(Float64ArrayObject);
 
 #undef DEFINE_CAST
 
+template <typename T>
+inline T* NullablePtr<T>::getValue()
+{
+    ASSERT(!!m_value);
+    return m_value;
+}
+
+template <typename T>
+inline const T* NullablePtr<T>::getValue() const
+{
+    ASSERT(!!m_value);
+    return m_value;
+}
+
+template struct NullablePtr<ValueRef>;
+
 inline ValueRef* toRef(const Value& v)
 {
     ASSERT(!v.isEmpty());

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -91,15 +91,8 @@ public:
     {
     }
 
-    T* getValue()
-    {
-        return m_value;
-    }
-
-    const T* getValue() const
-    {
-        return m_value;
-    }
+    T* getValue();
+    const T* getValue() const;
 
     bool hasValue() const
     {


### PR DESCRIPTION
* change to include assert guard code for getValue of NullablePtr
* when exception occurred, the result value is set to undefined which is never used but to avoid guard fail in NullablePtr

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>