### PR TITLE
Fix conversion to String for result value of SandBox run

### DIFF
--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -34,15 +34,10 @@ SandBox::SandBoxResult SandBox::run(const std::function<Value()>& scriptRunner)
     ExecutionState state(m_context);
     try {
         result.result = scriptRunner();
-        result.msgStr = result.result.toString(state);
+        result.msgStr = result.result.toStringWithoutException(state);
     } catch (const Value& err) {
         result.error = err;
-
-        try {
-            result.msgStr = result.error.toString(state);
-        } catch (const Value&) {
-            result.msgStr = String::fromASCII("Error while executing script but could not convert error to string");
-        }
+        result.msgStr = result.error.toStringWithoutException(state);
 
         fillStackDataIntoErrorObject(err);
 

--- a/src/runtime/Value.cpp
+++ b/src/runtime/Value.cpp
@@ -61,6 +61,21 @@ bool Value::isIterable() const
 }
 #endif
 
+String* Value::toStringWithoutException(ExecutionState& ec) const
+{
+    if (LIKELY(isString())) {
+        return asString();
+    }
+
+    String* result;
+    try {
+        result = toStringSlowCase(ec);
+    } catch (const Value&) {
+        result = String::fromASCII("Error while converting to string, but do not throw an exception");
+    }
+    return result;
+}
+
 Value Value::toPropertyKey(ExecutionState& state) const
 {
     // Let key be ? ToPrimitive(argument, hint String).

--- a/src/runtime/Value.h
+++ b/src/runtime/Value.h
@@ -209,6 +209,7 @@ public:
         }
         return toStringSlowCase(ec);
     }
+    String* toStringWithoutException(ExecutionState& ec) const;
     Object* toObject(ExecutionState& ec) const; // $7.1.13 ToObject
     Value toPropertyKey(ExecutionState& state) const;
 


### PR DESCRIPTION
* implement toStringWithoutException method not to throw any exception while converting to string value

NOTE
This patch also related with [issue #36](https://github.com/pando-project/escargot/issues/36)

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>