### PR TITLE
Set the result value of SandBox::run to undefined when exception occu…

### DIFF
--- a/src/runtime/SandBox.cpp
+++ b/src/runtime/SandBox.cpp
@@ -36,6 +36,9 @@ SandBox::SandBoxResult SandBox::run(const std::function<Value()>& scriptRunner)
         result.result = scriptRunner();
         result.msgStr = result.result.toStringWithoutException(state);
     } catch (const Value& err) {
+        // when exception occurred, an undefined value is allocated for result value which will be never used.
+        // this is to avoid dereferencing of null pointer.
+        result.result = Value();
         result.error = err;
         result.msgStr = result.error.toStringWithoutException(state);
 


### PR DESCRIPTION
…rred

* when exception occurred, the result value of SandBox::run will never be used
* undefined value is allocated to avoid dereferencing of null pointer

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>