### PR TITLE
Use default argument value in ByteCodeInterpreter::interpret()

### DIFF
--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -48,7 +48,7 @@ class GlobalObject;
 
 class ByteCodeInterpreter {
 public:
-    static Value interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile, void* initAddressFiller);
+    static Value interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile, void* initAddressFiller = nullptr);
     static Value loadByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, bool throwException = true);
     static EnvironmentRecord* getBindedEnvironmentRecordByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, Value& bindedValue, bool throwException = true);
     static void storeByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, const Value& value);

--- a/src/parser/Script.cpp
+++ b/src/parser/Script.cpp
@@ -76,8 +76,7 @@ Value Script::execute(ExecutionState& state, bool isEvalMode, bool needNewEnv, b
         literalStorage[i] = src[i];
     }
 
-    size_t unused;
-    Value resultValue = ByteCodeInterpreter::interpret(newState, m_topCodeBlock->byteCodeBlock(), 0, registerFile, &unused);
+    Value resultValue = ByteCodeInterpreter::interpret(newState, m_topCodeBlock->byteCodeBlock(), 0, registerFile);
     clearStack<512>();
 
     return resultValue;
@@ -183,8 +182,7 @@ Value Script::executeLocal(ExecutionState& state, Value thisValue, InterpretedCo
         }
     }
 
-    size_t unused;
-    Value resultValue = ByteCodeInterpreter::interpret(newState, m_topCodeBlock->byteCodeBlock(), 0, registerFile, &unused);
+    Value resultValue = ByteCodeInterpreter::interpret(newState, m_topCodeBlock->byteCodeBlock(), 0, registerFile);
     clearStack<512>();
 
     return resultValue;

--- a/src/runtime/FunctionObject.cpp
+++ b/src/runtime/FunctionObject.cpp
@@ -473,8 +473,7 @@ Value FunctionObject::processCall(ExecutionState& state, const Value& receiverSr
     }
 
     // run function
-    size_t unused;
-    const Value returnValue = ByteCodeInterpreter::interpret(newState, blk, 0, registerFile, &unused);
+    const Value returnValue = ByteCodeInterpreter::interpret(newState, blk, 0, registerFile);
     if (UNLIKELY(blk->m_shouldClearStack))
         clearStack<512>();
 


### PR DESCRIPTION
This patch is a bugfix for ARM-linux devices. When building Escargot with `arm-linux-gnueabi-g++` and `-O2` (default optimization level in CMake), the compiler does wrong optimizations in the [Opcode constructor](https://github.com/pando-project/escargot/blob/master/src/interpreter/ByteCode.cpp#L40). (Most probably the last parameter of `ByteCodeInterpreter::interpret` is optimized out.) In this case the opcode table is not initialized that results a Segmentation fault.

Since the last parameter of `ByteCodeInterpreter::interpret` is only used once (at initialization), I've refactored a code to define a default `nullptr` value for that. This helps to have a cleaner code (no unnecessary `unused` variables) and Escargot could work with the default CMake compiler options (e.g. `-O2`).