### PR TITLE
Guard Object builtin functions which have conflicts with ES5.1

### DIFF
--- a/src/runtime/GlobalObjectBuiltinObject.cpp
+++ b/src/runtime/GlobalObjectBuiltinObject.cpp
@@ -60,9 +60,13 @@ static Value builtinObjectValueOf(ExecutionState& state, Value thisValue, size_t
 
 static Value builtinObjectPreventExtensions(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    // If Type(O) is not Object, throw a TypeError exception.
     if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        return argv[0];
+#else
+        // If Type(O) is not Object, throw a TypeError exception.
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().defineProperty.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
+#endif
     }
     Object* o = argv[0].asObject();
     o->preventExtensions(state);
@@ -265,17 +269,15 @@ static Value builtinObjectSetPrototypeOf(ExecutionState& state, Value thisValue,
 
 static Value builtinObjectFreeze(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-#if defined(ESCARGOT_ENABLE_VENDORTEST) || defined(ESCARGOT_SHELL)
-    // If Type(O) is not Object throw a TypeError exception. (ES5)
     if (!argv[0].isObject()) {
-        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().freeze.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
-    }
-#else
-    // If Type(O) is not Object, return O. (ES6)
-    if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        // If Type(O) is not Object, return O. (ES6)
         return argv[0];
-    }
+#else
+        // If Type(O) is not Object throw a TypeError exception. (ES5)
+        ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().freeze.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
 #endif
+    }
 
     Object* O = argv[0].asObject();
     //O->markThisObjectDontNeedStructureTransitionTable(state);
@@ -411,9 +413,13 @@ static Value builtinObjectGetOwnPropertySymbols(ExecutionState& state, Value thi
 
 static Value builtinObjectIsExtensible(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    // If Type(O) is not Object throw a TypeError exception.
     if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        return Value(Value::False);
+#else
+        // If Type(O) is not Object throw a TypeError exception.
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().seal.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
+#endif
     }
     // Return the Boolean value of the [[Extensible]] internal property of O.
     return Value(argv[0].asObject()->isExtensible(state));
@@ -421,9 +427,13 @@ static Value builtinObjectIsExtensible(ExecutionState& state, Value thisValue, s
 
 static Value builtinObjectIsFrozen(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    // If Type(O) is not Object throw a TypeError exception.
     if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        return Value(Value::True);
+#else
+        // If Type(O) is not Object throw a TypeError exception.
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().seal.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
+#endif
     }
     Object* O = argv[0].asObject();
 
@@ -451,9 +461,13 @@ static Value builtinObjectIsFrozen(ExecutionState& state, Value thisValue, size_
 
 static Value builtinObjectIsSealed(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    // If Type(O) is not Object throw a TypeError exception.
     if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        return Value(Value::True);
+#else
+        // If Type(O) is not Object throw a TypeError exception.
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().seal.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
+#endif
     }
     Object* O = argv[0].asObject();
 
@@ -525,9 +539,13 @@ static Value builtinObjectKeys(ExecutionState& state, Value thisValue, size_t ar
 
 static Value builtinObjectSeal(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    // If Type(O) is not Object throw a TypeError exception.
     if (!argv[0].isObject()) {
+#if ESCARGOT_ENABLE_ES2015
+        return argv[0];
+#else
+        // If Type(O) is not Object throw a TypeError exception.
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, state.context()->staticStrings().Object.string(), false, state.context()->staticStrings().seal.string(), errorMessage_GlobalObject_FirstArgumentNotObject);
+#endif
     }
     Object* O = argv[0].asObject();
 

--- a/test/es2015/object-builtin.js
+++ b/test/es2015/object-builtin.js
@@ -1,0 +1,24 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+assert(typeof Object.getPrototypeOf("foo") === "object");
+assert(Object.getPrototypeOf("foo") === String.prototype);
+
+assert(Object.preventExtensions(1) === 1);
+assert(Object.freeze(1) === 1);
+assert(Object.seal(1) === 1);
+assert(Object.isExtensible(1) === false);
+assert(Object.isFrozen(1) === true);
+assert(Object.isSealed(1) === true);


### PR DESCRIPTION
… ES6

* update preventExtensions, freeze, seal, isExtensible, isFrozen, isSealed builtin functions

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>