### PR TITLE
Change std::list to vector type

### DIFF
--- a/src/runtime/StaticStrings.cpp
+++ b/src/runtime/StaticStrings.cpp
@@ -107,20 +107,20 @@ void StaticStrings::initStaticStrings(AtomicStringMap* atomicStringMap)
 
 ::Escargot::String* StaticStrings::dtoa(double d) const
 {
-    auto iter = dtoaCache.begin();
+    size_t size = dtoaCache.size();
 
-    while (iter != dtoaCache.end()) {
-        if ((*iter).first == d) {
-            return (*iter).second;
+    for (size_t i = 0; i < size; ++i) {
+        if (dtoaCache[i].first == d) {
+            return dtoaCache[i].second;
         }
-        iter++;
     }
 
     ::Escargot::String* s = String::fromDouble(d);
-    dtoaCache.push_front(std::make_pair(d, s));
+    dtoaCache.insert(0, std::make_pair(d, s));
     if (dtoaCache.size() > dtoaCacheSize) {
-        dtoaCache.pop_back();
+        dtoaCache.erase(dtoaCache.size() - 1);
     }
+
     return s;
 }
 }

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -466,7 +466,8 @@ public:
     void initStaticStrings(AtomicStringMap* map);
 
     const size_t dtoaCacheSize; // 5;
-    mutable std::list<std::pair<double, ::Escargot::String*>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<double, ::Escargot::String*>>> dtoaCache;
+    mutable Vector<std::pair<double, ::Escargot::String*>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<double, ::Escargot::String*>>> dtoaCache;
+    //mutable std::list<std::pair<double, ::Escargot::String*>, GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<double, ::Escargot::String*>>> dtoaCache;
 
     ::Escargot::String* dtoa(double d) const;
 };


### PR DESCRIPTION
I guess that "std::list" is not compatible to our GC. 
So, while LWE is destroyed, std::list happens crash because of this issue.
So, I changed it to vector type.

Signed-off-by: Seungsoo Lee <seungsoo47.lee@samsung.com>