### PR TITLE
Convert to non-fast-mode array when preventExtensions called

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -855,9 +855,9 @@ bool ObjectRef::isExtensible(ExecutionStateRef* state)
     return toImpl(this)->isExtensible(*toImpl(state));
 }
 
-void ObjectRef::preventExtensions(ExecutionStateRef* state)
+bool ObjectRef::preventExtensions(ExecutionStateRef* state)
 {
-    toImpl(this)->preventExtensions(*toImpl(state));
+    return toImpl(this)->preventExtensions(*toImpl(state));
 }
 
 void* ObjectRef::extraData()

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -535,7 +535,7 @@ public:
     void enumerateObjectOwnProperies(ExecutionStateRef* state, const std::function<bool(ExecutionStateRef* state, ValueRef* propertyName, bool isWritable, bool isEnumerable, bool isConfigurable)>& cb);
 
     bool isExtensible(ExecutionStateRef* state);
-    void preventExtensions(ExecutionStateRef* state);
+    bool preventExtensions(ExecutionStateRef* state);
 
     void* extraData();
     void setExtraData(void* e);

--- a/src/runtime/ArrayObject.cpp
+++ b/src/runtime/ArrayObject.cpp
@@ -409,6 +409,14 @@ bool ArrayObject::setIndexedProperty(ExecutionState& state, const Value& propert
     return set(state, ObjectPropertyName(state, property), value, this);
 }
 
+bool ArrayObject::preventExtensions(ExecutionState& state)
+{
+    // first, convert to non-fast-mode.
+    // then, set preventExtensions
+    convertIntoNonFastMode(state);
+    return Object::preventExtensions(state);
+}
+
 ArrayIteratorObject::ArrayIteratorObject(ExecutionState& state, Object* a, Type type)
     : IteratorObject(state)
     , m_array(a)

--- a/src/runtime/ArrayObject.h
+++ b/src/runtime/ArrayObject.h
@@ -67,6 +67,7 @@ public:
     virtual void sort(ExecutionState& state, const std::function<bool(const Value& a, const Value& b)>& comp) override;
     virtual ObjectGetResult getIndexedProperty(ExecutionState& state, const Value& property) override;
     virtual bool setIndexedProperty(ExecutionState& state, const Value& property, const Value& value) override;
+    virtual bool preventExtensions(ExecutionState&) override;
 
     // Use custom allocator for Array object (for Badtime)
     void* operator new(size_t size);

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -595,12 +595,8 @@ public:
         return rareData() == nullptr ? true : rareData()->m_isExtensible;
     }
 
-// http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-#if ESCARGOT_ENABLE_PROXY_REFLECT
+    // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
     virtual bool preventExtensions(ExecutionState&)
-#else
-    bool preventExtensions(ExecutionState&)
-#endif
     {
         ensureObjectRareData()->m_isExtensible = false;
         return true;

--- a/test/regression-tests/issue-185.js
+++ b/test/regression-tests/issue-185.js
@@ -1,0 +1,32 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  var a = Object.preventExtensions([1, , 3, , 4, 5]);
+  try {
+    a.copyWithin(2, 1, 4);
+    assert(false);
+  } catch (e) {
+    assert(e instanceof TypeError);
+  }
+})();
+
+(function () {
+  var a = Object.preventExtensions([1, , 3, , 4, 5]);
+  a[1] = 1;
+  a[2] = 2;
+  assert(a[1] === undefined);
+  assert(a[2] === 2);
+})();


### PR DESCRIPTION
Fixes #185 

* first, convert to non-fast-mode and then, set non-extensible
* preventExtensions api is also updated

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>