### PR TITLE
Use std::mt19937 instead of rand() function for Math.random() builtin

### DIFF
--- a/src/Escargot.h
+++ b/src/Escargot.h
@@ -163,6 +163,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <random>
 
 #ifdef ENABLE_ICU
 #include <unicode/locid.h>

--- a/src/runtime/GlobalObjectBuiltinMath.cpp
+++ b/src/runtime/GlobalObjectBuiltinMath.cpp
@@ -380,8 +380,8 @@ static Value builtinMathLog2(ExecutionState& state, Value thisValue, size_t argc
 
 static Value builtinMathRandom(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)
 {
-    double rand = (double)std::rand() / RAND_MAX;
-    return Value(rand);
+    std::uniform_real_distribution<double> distribution;
+    return Value(distribution(state.context()->vmInstance()->randEngine()));
 }
 
 static Value builtinMathExp(ExecutionState& state, Value thisValue, size_t argc, Value* argv, bool isNewExpression)

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -163,7 +163,8 @@ static ObjectPropertyNativeGetterSetterData regexpLastIndexGetterSetterData(
     true, false, false, &VMInstance::regexpLastIndexNativeGetter, &VMInstance::regexpLastIndexNativeSetter);
 
 VMInstance::VMInstance(const char* locale, const char* timezone)
-    : m_didSomePrototypeObjectDefineIndexedProperty(false)
+    : m_randEngine((unsigned int)time(NULL))
+    , m_didSomePrototypeObjectDefineIndexedProperty(false)
     , m_compiledByteCodeSize(0)
     , m_cachedUTC(nullptr)
 {

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -206,6 +206,11 @@ public:
         return m_compiledByteCodeSize;
     }
 
+    std::mt19937& randEngine()
+    {
+        return m_randEngine;
+    }
+
 private:
     StaticStrings m_staticStrings;
     AtomicStringMap m_atomicStringMap;
@@ -215,6 +220,8 @@ private:
     std::unordered_map<void*, size_t, std::hash<void*>, std::equal_to<void*>,
                        GCUtil::gc_malloc_ignore_off_page_allocator<std::pair<void* const, size_t>>>
         m_rootSet;
+
+    std::mt19937 m_randEngine;
 
     // this flag should affect VM-wide array object
     bool m_didSomePrototypeObjectDefineIndexedProperty;

--- a/src/shell/Shell.cpp
+++ b/src/shell/Shell.cpp
@@ -81,8 +81,6 @@ int main(int argc, char* argv[])
     setbuf(stderr, NULL);
 #endif
 
-    srand(time(NULL));
-
     Escargot::Heap::initialize();
     Escargot::VMInstance* instance = new Escargot::VMInstance();
     Escargot::Context* context = new Escargot::Context(instance);


### PR DESCRIPTION
Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>