### PR TITLE
Use a copied ObjectStructure in Object::enumeration

### DIFF
--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -19,6 +19,7 @@
 
 #include "Escargot.h"
 #include "Object.h"
+#include "ObjectStructure.h"
 #include "ExecutionContext.h"
 #include "Context.h"
 #include "VMInstance.h"
@@ -714,9 +715,10 @@ bool Object::deleteOwnProperty(ExecutionState& state, const ObjectPropertyName& 
 
 void Object::enumeration(ExecutionState& state, bool (*callback)(ExecutionState& state, Object* self, const ObjectPropertyName&, const ObjectStructurePropertyDescriptor& desc, void* data), void* data, bool shouldSkipSymbolKey) ESCARGOT_OBJECT_SUBCLASS_MUST_REDEFINE
 {
-    size_t cnt = m_structure->propertyCount();
+    ObjectStructure structure(*m_structure);
+    size_t cnt = structure.propertyCount();
     for (size_t i = 0; i < cnt; i++) {
-        const ObjectStructureItem& item = m_structure->readProperty(state, i);
+        const ObjectStructureItem& item = structure.readProperty(state, i);
         if (shouldSkipSymbolKey && item.m_propertyName.isSymbol()) {
             continue;
         }

--- a/test/regression-tests/issue-128.js
+++ b/test/regression-tests/issue-128.js
@@ -1,0 +1,20 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var bDeletesC = {$ : $, get b() { delete this.$ }, c: $};   
+var $ = Object.values(bDeletesC);
+
+assert(JSON.stringify($) == '[null,null,null]');
+assert(JSON.stringify(Object.keys(bDeletesC)) == '["b","c"]');


### PR DESCRIPTION
Fixes #128

Signed-off-by: Peter Marki marpeter@inf.u-szeged.hu