### PR TITLE
Fix the bytecode generation of the template literals quasis

### DIFF
--- a/src/parser/ast/TemplateLiteralNode.h
+++ b/src/parser/ast/TemplateLiteralNode.h
@@ -66,11 +66,13 @@ public:
             context->giveUpRegister();
 
             String* str = new UTF16String(std::move((*m_quasis)[i + 1]->value));
-            codeBlock->m_literalData.push_back(str);
-            size_t reg = context->getRegister();
-            codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), reg, Value(str)), context, this);
-            codeBlock->pushCode(TemplateOperation(ByteCodeLOC(m_loc.index), dstRegister, eSrc, dstRegister), context, this);
-            context->giveUpRegister();
+            if (str->length()) {
+                codeBlock->m_literalData.push_back(str);
+                size_t reg = context->getRegister();
+                codeBlock->pushCode(LoadLiteral(ByteCodeLOC(m_loc.index), reg, Value(str)), context, this);
+                codeBlock->pushCode(TemplateOperation(ByteCodeLOC(m_loc.index), dstRegister, reg, dstRegister), context, this);
+                context->giveUpRegister();
+            }
         }
     }
 

--- a/test/regression-tests/issue-125.js
+++ b/test/regression-tests/issue-125.js
@@ -1,0 +1,32 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var hello = function() {
+  var a = "world"
+  return `Hello ${a}`
+}
+assert(hello() === "Hello world");
+
+hello = function() {
+  var a = "world"
+  var b = "universe"
+  return `Hello ${a} and beautiful ${b} and thanks for the fish`
+}
+
+assert(hello() === "Hello world and beautiful universe and thanks for the fish");


### PR DESCRIPTION
This patch fixes #125.

Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu