### PR TITLE
Fix bugs in Map and Set

### DIFF
--- a/src/runtime/GlobalObjectBuiltinMap.cpp
+++ b/src/runtime/GlobalObjectBuiltinMap.cpp
@@ -246,13 +246,13 @@ void GlobalObject::installMap(ExecutionState& state)
                                                      ObjectPropertyDescriptor(entFn, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_mapPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().iterator),
-                                                     ObjectPropertyDescriptor(entFn, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
+                                                     ObjectPropertyDescriptor(entFn, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_mapPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().toStringTag)),
                                                      ObjectPropertyDescriptor(Value(state.context()->staticStrings().Map.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));
 
     JSGetterSetter gs(
-        new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().function, builtinMapSizeGetter, 0, nullptr, NativeFunctionInfo::Strict)),
+        new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().getSize, builtinMapSizeGetter, 0, nullptr, NativeFunctionInfo::Strict)),
         Value(Value::EmptyValue));
     ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
     m_mapPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);

--- a/src/runtime/GlobalObjectBuiltinSet.cpp
+++ b/src/runtime/GlobalObjectBuiltinSet.cpp
@@ -219,12 +219,12 @@ void GlobalObject::installSet(ExecutionState& state)
                                                      ObjectPropertyDescriptor(new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().entries, builtinSetEntries, 0, nullptr, NativeFunctionInfo::Strict)), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_setPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().iterator),
-                                                     ObjectPropertyDescriptor(valuesFn, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::AllPresent)));
+                                                     ObjectPropertyDescriptor(valuesFn, (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
 
     m_setPrototype->defineOwnPropertyThrowsException(state, ObjectPropertyName(state, Value(state.context()->vmInstance()->globalSymbols().toStringTag)),
                                                      ObjectPropertyDescriptor(Value(state.context()->staticStrings().Set.string()), (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::ConfigurablePresent)));
     JSGetterSetter gs(
-        new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().function, builtinSetSizeGetter, 0, nullptr, NativeFunctionInfo::Strict)),
+        new FunctionObject(state, NativeFunctionInfo(AtomicString(state, String::fromASCII("get size")), builtinSetSizeGetter, 0, nullptr, NativeFunctionInfo::Strict)),
         Value(Value::EmptyValue));
     ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
     m_setPrototype->defineOwnProperty(state, ObjectPropertyName(state.context()->staticStrings().size), desc);

--- a/src/runtime/GlobalObjectBuiltinTypedArray.cpp
+++ b/src/runtime/GlobalObjectBuiltinTypedArray.cpp
@@ -1746,7 +1746,7 @@ void GlobalObject::installTypedArray(ExecutionState& state)
                                                                                    (ObjectPropertyDescriptor::PresentAttribute)(ObjectPropertyDescriptor::WritablePresent | ObjectPropertyDescriptor::ConfigurablePresent)));
     {
         JSGetterSetter gs(
-            new FunctionObject(state, NativeFunctionInfo(AtomicString(state, String::fromASCII("get [Symbol.toStringTag]")), builtinTypedArrayToStringTagGetter, 0, nullptr, NativeFunctionInfo::Strict)),
+            new FunctionObject(state, NativeFunctionInfo(state.context()->staticStrings().getSymbolToStringTag, builtinTypedArrayToStringTagGetter, 0, nullptr, NativeFunctionInfo::Strict)),
             Value(Value::EmptyValue));
         ObjectPropertyDescriptor desc(gs, ObjectPropertyDescriptor::ConfigurablePresent);
         typedArrayPrototype->defineOwnProperty(state, ObjectPropertyName(state, state.context()->vmInstance()->globalSymbols().toStringTag), desc);

--- a/src/runtime/StaticStrings.cpp
+++ b/src/runtime/StaticStrings.cpp
@@ -83,8 +83,10 @@ void StaticStrings::initStaticStrings(AtomicStringMap* atomicStringMap)
     getbyteOffset.init(atomicStringMap, "get byteOffset", strlen("get byteOffset"));
     getLength.init(atomicStringMap, "get length", strlen("get length"));
     getBuffer.init(atomicStringMap, "get buffer", strlen("get buffer"));
+    getSize.init(atomicStringMap, "get size", strlen("get size"));
     getSymbolSpecies.init(atomicStringMap, "get [Symbol.species]", strlen("get [Symbol.species]"));
     getSymbolSearch.init(atomicStringMap, "get [Symbol.search]", strlen("get [Symbol.search]"));
+    getSymbolToStringTag.init(atomicStringMap, "get [Symbol.toStringTag]", strlen("get [Symbol.toStringTag]"));
     $Ampersand.init(atomicStringMap, "$&", strlen("$&"));
     $PlusSign.init(atomicStringMap, "$+", strlen("$+"));
     $GraveAccent.init(atomicStringMap, "$`", strlen("$`"));

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -448,8 +448,10 @@ public:
     AtomicString getbyteOffset;
     AtomicString getLength;
     AtomicString getBuffer;
+    AtomicString getSize;
     AtomicString getSymbolSpecies;
     AtomicString getSymbolSearch;
+    AtomicString getSymbolToStringTag;
     AtomicString $Ampersand;
     AtomicString $PlusSign;
     AtomicString $GraveAccent;

--- a/test/es2015/map-set.js
+++ b/test/es2015/map-set.js
@@ -1,0 +1,128 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var map = new Map();
+
+var objectKey = {};
+var stringKey = 'keykeykey';
+var numberKey = 42.24;
+var booleanKey = true;
+var undefinedKey = undefined;
+var nullKey = null;
+var nanKey = NaN;
+var zeroKey = 0;
+var minusZeroKey = -0;
+
+assert(map.size === 0);
+
+map.set(objectKey, 'aaa');
+map.set(stringKey, 'bbb');
+map.set(numberKey, 'ccc');
+map.set(booleanKey, 'ddd');
+map.set(undefinedKey, 'eee');
+map.set(nullKey, 'fff');
+map.set(nanKey, 'ggg');
+map.set(zeroKey, 'hhh');
+
+assert(8 === map.size);
+
+assert('aaa' === map.get(objectKey));
+assert('bbb' === map.get(stringKey));
+assert('ccc' === map.get(numberKey));
+assert('ddd' === map.get(booleanKey));
+assert('eee' === map.get(undefinedKey));
+assert('fff' === map.get(nullKey));
+assert('ggg' === map.get(nanKey));
+assert('hhh' === map.get(zeroKey));
+
+assert(undefined === map.get({}));
+assert('bbb' === map.get('keykeykey'));
+assert('ccc' === map.get(42.24));
+assert('ddd' === map.get(true));
+assert('eee' === map.get(undefined));
+assert('fff' === map.get(null));
+assert('ggg' === map.get(NaN));
+assert('hhh' === map.get(0));
+assert('hhh' === map.get(-0));
+assert('hhh' === map.get(1 / Infinity));
+assert('hhh' === map.get(-1 / Infinity));
+
+var set = new Set();
+
+var objectKey = {};
+var stringKey = 'keykeykey';
+var numberKey = 42.24;
+var booleanKey = true;
+var undefinedKey = undefined;
+var nullKey = null;
+var nanKey = NaN;
+var zeroKey = 0;
+var minusZeroKey = -0;
+
+assert(set.size === 0);
+
+set.add(objectKey);
+set.add(stringKey);
+set.add(numberKey);
+set.add(booleanKey);
+set.add(undefinedKey);
+set.add(nullKey);
+set.add(nanKey);
+set.add(zeroKey);
+
+assert(8 === set.size);
+
+assert(set.has(objectKey));
+assert(set.has(stringKey));
+assert(set.has(numberKey));
+assert(set.has(booleanKey));
+assert(set.has(undefinedKey));
+assert(set.has(nullKey));
+assert(set.has(nanKey));
+assert(set.has(zeroKey));
+
+assert(!set.has({}));
+assert(set.has('keykeykey'));
+assert(set.has(42.24));
+assert(set.has(true));
+assert(set.has(undefined));
+assert(set.has(null));
+assert(set.has(NaN));
+assert(set.has(0));
+assert(set.has(-0));
+assert(set.has(1 / Infinity));
+assert(set.has(-1 / Infinity));
+
+(function TestSetIteratorSymbol() {
+  assert(Set.prototype[Symbol.iterator] === Set.prototype.values);
+  assert(Set.prototype.hasOwnProperty(Symbol.iterator));
+  assert(!Set.prototype.propertyIsEnumerable(Symbol.iterator));
+
+  var iter = new Set().values();
+  assert(iter === iter[Symbol.iterator]());
+  assert(iter[Symbol.iterator].name === '[Symbol.iterator]');
+})();
+
+(function TestMapIteratorSymbol() {
+  assert(Map.prototype[Symbol.iterator], Map.prototype.entries);
+  assert(Map.prototype.hasOwnProperty(Symbol.iterator));
+  assert(!Map.prototype.propertyIsEnumerable(Symbol.iterator));
+
+  var iter = new Map().values();
+  assert(iter === iter[Symbol.iterator]());
+  assert(iter[Symbol.iterator].name === '[Symbol.iterator]');
+})();


### PR DESCRIPTION
* update the name of builtin size getter function
* Symbol.iterator property should not be enumerable
* add internal test cases of Map and Set

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>