### PR TITLE
Add missing checks for targetDescriptor in ProxyObject::get

### DIFF
--- a/src/runtime/ProxyObject.cpp
+++ b/src/runtime/ProxyObject.cpp
@@ -681,16 +681,16 @@ ObjectGetResult ProxyObject::get(ExecutionState& state, const ObjectPropertyName
 
     // 13. If targetDesc is not undefined, then
     if (!targetDesc.value(state, target).isUndefined()) {
-        // a. TODO If IsDataDescriptor(targetDesc) and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
-        if (!targetDesc.isConfigurable() && !targetDesc.isWritable()) {
+        // a. If IsDataDescriptor(targetDesc) and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
+        if (targetDesc.isDataProperty() && !targetDesc.isConfigurable() && !targetDesc.isWritable()) {
             // i. If SameValue(trapResult, targetDesc.[[Value]]) is false, throw a TypeError exception.
             if (trapResult != targetDesc.value(state, target)) {
                 ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, strings->Proxy.string(), false, String::emptyString, "%s: Proxy Type Error.");
                 return ObjectGetResult();
             }
         }
-        // b. TODO If IsAccessorDescriptor(targetDesc) and targetDesc.[[Configurable]] is false and targetDesc.[[Get]] is undefined, then
-        if (!targetDesc.isConfigurable() && (!targetDesc.jsGetterSetter()->hasGetter() || targetDesc.jsGetterSetter()->getter().isUndefined())) {
+        // b. If IsAccessorDescriptor(targetDesc) and targetDesc.[[Configurable]] is false and targetDesc.[[Get]] is undefined, then
+        if (!targetDesc.isDataProperty() && !targetDesc.isConfigurable() && (!targetDesc.jsGetterSetter()->hasGetter() || targetDesc.jsGetterSetter()->getter().isUndefined())) {
             // i. If trapResult is not undefined, throw a TypeError exception.
             if (!trapResult.isUndefined()) {
                 ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, strings->Proxy.string(), false, String::emptyString, "%s: Proxy Type Error.");

--- a/test/regression-tests/xfail/issue-232.js
+++ b/test/regression-tests/xfail/issue-232.js
@@ -1,0 +1,22 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var handler = {
+  get: function () {}
+};
+
+var proxy = new Proxy([ ], handler);
+var boundFilter = Array.prototype.filter.bind(proxy);
+boundFilter();


### PR DESCRIPTION
Check if the descriptor is dataDescriptor / accessorDescriptor.

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>