### PR TITLE
Implement ESCARGOT_TREAT_LET_AS_VAR env variable

### DIFF
--- a/src/parser/Lexer.cpp
+++ b/src/parser/Lexer.cpp
@@ -1731,6 +1731,10 @@ static ALWAYS_INLINE KeywordKind isKeyword(const StringBufferAccessData& data)
         break;
     case 'l':
         if (length == 3 && data.equalsSameLength("let", 1)) {
+            const char* env = getenv("ESCARGOT_TREAT_LET_AS_VAR");
+            if (env && strlen(env)) {
+                return VarKeyword;
+            }
             return LetKeyword;
         }
         break;


### PR DESCRIPTION
This is bad implementation. but it is needed for some special reason

Signed-off-by: seonghyun kim <sh8281.kim@samsung.com>