### PR TITLE
Simplify the OpcodeTable initialization.

### DIFF
--- a/src/interpreter/ByteCode.cpp
+++ b/src/interpreter/ByteCode.cpp
@@ -32,13 +32,10 @@ OpcodeTable g_opcodeTable;
 
 OpcodeTable::OpcodeTable()
 {
-    ExecutionState state((Context*)nullptr);
-    ByteCodeBlock block;
-
-    block.m_code.resize(sizeof(FillOpcodeTable));
 #if defined(COMPILER_GCC)
-    size_t* addr = (size_t*)(block.m_code.data() + offsetof(FillOpcodeTable, m_opcodeInAddress));
-    ByteCodeInterpreter::interpret(state, &block, 0, nullptr, addr);
+    ExecutionState state((Context*)nullptr);
+    // Dummy bytecode execution to initialize the OpcodeTable.
+    ByteCodeInterpreter::interpret(state, nullptr, 0, nullptr);
 #endif
 }
 

--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -120,7 +120,6 @@ class Node;
     F(CallEvalFunction, 0, 0)                         \
     F(CallFunctionInWithScope, 0, 0)                  \
     F(BindingRestElement, 1, 0)                       \
-    F(FillOpcodeTable, 0, 0)                          \
     F(End, 0, 0)
 
 enum Opcode {
@@ -1907,21 +1906,6 @@ public:
     void dump(const char* byteCodeStart)
     {
         printf("end");
-    }
-#endif
-};
-
-class FillOpcodeTable : public ByteCode {
-public:
-    FillOpcodeTable()
-        : ByteCode(Opcode::FillOpcodeTableOpcode, ByteCodeLOC(0))
-    {
-    }
-
-#ifndef NDEBUG
-    void dump(const char* byteCodeStart)
-    {
-        RELEASE_ASSERT_NOT_REACHED();
     }
 #endif
 };

--- a/src/interpreter/ByteCodeInterpreter.cpp
+++ b/src/interpreter/ByteCodeInterpreter.cpp
@@ -55,19 +55,22 @@ ALWAYS_INLINE size_t resolveProgramCounter(char* codeBuffer, const size_t progra
     return programCounter - (size_t)codeBuffer;
 }
 
-Value ByteCodeInterpreter::interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile, void* initAddressFiller)
+Value ByteCodeInterpreter::interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile)
 {
 #if defined(COMPILER_GCC)
-    if (UNLIKELY(initAddressFiller != nullptr)) {
-        *((size_t*)initAddressFiller) = ((size_t) && FillOpcodeTableOpcodeLbl);
+    if (UNLIKELY(byteCodeBlock == nullptr)) {
+        goto FillOpcodeTableLbl;
     }
 #endif
 
-    ExecutionContext* ec = state.executionContext();
-    char* codeBuffer = byteCodeBlock->m_code.data();
-    programCounter = (size_t)(codeBuffer + programCounter);
+    ASSERT(byteCodeBlock != nullptr);
+    ASSERT(registerFile != nullptr);
 
     {
+        ExecutionContext* ec = state.executionContext();
+        char* codeBuffer = byteCodeBlock->m_code.data();
+        programCounter = (size_t)(codeBuffer + programCounter);
+
         try {
 #if defined(COMPILER_GCC)
 
@@ -1341,7 +1344,7 @@ Value ByteCodeInterpreter::interpret(ExecutionState& state, ByteCodeBlock* byteC
     ASSERT_NOT_REACHED();
 
 #if defined(COMPILER_GCC)
-FillOpcodeTableOpcodeLbl:
+FillOpcodeTableLbl:
 #define REGISTER_TABLE(opcode, pushCount, popCount) g_opcodeTable.m_table[opcode##Opcode] = &&opcode##OpcodeLbl;
     FOR_EACH_BYTECODE_OP(REGISTER_TABLE);
 #undef REGISTER_TABLE

--- a/src/interpreter/ByteCodeInterpreter.h
+++ b/src/interpreter/ByteCodeInterpreter.h
@@ -50,7 +50,7 @@ class GlobalObject;
 
 class ByteCodeInterpreter {
 public:
-    static Value interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile, void* initAddressFiller = nullptr);
+    static Value interpret(ExecutionState& state, ByteCodeBlock* byteCodeBlock, size_t programCounter, Value* registerFile);
     static Value loadByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, bool throwException = true);
     static EnvironmentRecord* getBindedEnvironmentRecordByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, Value& bindedValue, bool throwException = true);
     static void storeByName(ExecutionState& state, LexicalEnvironment* env, const AtomicString& name, const Value& value);


### PR DESCRIPTION
Pass null pointers for `ByteCodeInterpreter::interpret` to indicate the `OpcodeTable` initialization. In this case the `FillOpcodeTable` opcode can be removed.