### PR TITLE
Modify RegExp property getters, isRegExpObject check

### DIFF
--- a/src/api/EscargotPublic.cpp
+++ b/src/api/EscargotPublic.cpp
@@ -344,14 +344,14 @@ BooleanObjectRef* PointerValueRef::asBooleanObject()
     return toRef(toImpl(this)->asBooleanObject());
 }
 
-bool PointerValueRef::isRegExpObject()
+bool PointerValueRef::isRegExpObject(ExecutionState& state)
 {
-    return toImpl(this)->isRegExpObject();
+    return toImpl(this)->isRegExpObject(state);
 }
 
-RegExpObjectRef* PointerValueRef::asRegExpObject()
+RegExpObjectRef* PointerValueRef::asRegExpObject(ExecutionState& state)
 {
-    return toRef(toImpl(this)->asRegExpObject());
+    return toRef(toImpl(this)->asRegExpObject(state));
 }
 
 bool PointerValueRef::isDateObject()

--- a/src/api/EscargotPublic.h
+++ b/src/api/EscargotPublic.h
@@ -144,8 +144,8 @@ public:
     NumberObjectRef* asNumberObject();
     bool isBooleanObject();
     BooleanObjectRef* asBooleanObject();
-    bool isRegExpObject();
-    RegExpObjectRef* asRegExpObject();
+    bool isRegExpObject(ExecutionState& state);
+    RegExpObjectRef* asRegExpObject(ExecutionState& state);
     bool isDateObject();
     DateObjectRef* asDateObject();
     bool isGlobalObject();

--- a/src/runtime/GlobalObjectBuiltinString.cpp
+++ b/src/runtime/GlobalObjectBuiltinString.cpp
@@ -186,8 +186,8 @@ static Value builtinStringMatch(ExecutionState& state, Value thisValue, size_t a
     RESOLVE_THIS_BINDING_TO_STRING(str, String, match);
     Value argument = argv[0];
     RegExpObject* regexp;
-    if (argument.isPointerValue() && argument.asPointerValue()->isRegExpObject()) {
-        regexp = argument.asPointerValue()->asRegExpObject();
+    if (argument.isPointerValue() == true && argument.asPointerValue()->isRegExpObject(state) == true) {
+        regexp = argument.asPointerValue()->asRegExpObject(state);
     } else {
         regexp = new RegExpObject(state, argument.isUndefined() ? String::emptyString : argument.toString(state), String::emptyString);
     }
@@ -314,8 +314,8 @@ static Value builtinStringReplace(ExecutionState& state, Value thisValue, size_t
     bool replaceValueIsFunction = replaceValue.isFunction();
     RegexMatchResult result;
 
-    if (searchValue.isPointerValue() && searchValue.asPointerValue()->isRegExpObject()) {
-        RegExpObject* regexp = searchValue.asPointerValue()->asRegExpObject();
+    if (searchValue.isPointerValue() == true && searchValue.asPointerValue()->isRegExpObject(state) == true) {
+        RegExpObject* regexp = searchValue.asPointerValue()->asRegExpObject(state);
         bool isGlobal = regexp->option() & RegExpObject::Option::Global;
 
         if (isGlobal) {
@@ -493,9 +493,9 @@ static Value builtinStringSearch(ExecutionState& state, Value thisValue, size_t 
     Value parameter[1] = { Value(string) };
     return func.asObject()->asFunctionObject()->call(state, rx, 1, parameter);
 #else
-    if (regexp.isPointerValue() && regexp.asPointerValue()->isRegExpObject()) {
+    if (regexp.isPointerValue() == true && regexp.asPointerValue()->isRegExpObject(state) == true) {
         // If Type(regexp) is Object and the value of the [[Class]] internal property of regexp is "RegExp", then let rx be regexp;
-        rx = regexp.asPointerValue()->asRegExpObject();
+        rx = regexp.asPointerValue()->asRegExpObject(state);
     } else {
         // Else, let rx be a new RegExp object created as if by the expression new RegExp(regexp) where RegExp is the standard built-in constructor with that name.
         rx = new RegExpObject(state, regexp.isUndefined() ? String::emptyString : regexp.toString(state), String::emptyString);
@@ -542,8 +542,8 @@ static Value builtinStringSplit(ExecutionState& state, Value thisValue, size_t a
     // If limit is undefined, let lim = 2^32 – 1; else let lim = ToUint32(limit).
     lim = limit.isUndefined() ? Value::InvalidIndexValue - 1 : limit.toUint32(state);
     // If separator is a RegExp object (its [[Class]] is "RegExp"), let R = separator; otherwise let R = ToString(separator).
-    if (separator.isPointerValue() && separator.asPointerValue()->isRegExpObject()) {
-        P = separator.asPointerValue()->asRegExpObject();
+    if (separator.isPointerValue() == true && separator.asPointerValue()->isRegExpObject(state) == true) {
+        P = separator.asPointerValue()->asRegExpObject(state);
     } else {
         P = separator.toString(state);
     }
@@ -579,9 +579,9 @@ static Value builtinStringSplit(ExecutionState& state, Value thisValue, size_t a
     };
     if (s == 0) {
         bool ret = true;
-        if (P->isRegExpObject()) {
+        if (P->isRegExpObject(state) == true) {
             RegexMatchResult result;
-            ret = P->asRegExpObject()->matchNonGlobally(state, S, result, false, 0);
+            ret = P->asRegExpObject(state)->matchNonGlobally(state, S, result, false, 0);
         } else {
             Value z = splitMatchUsingStr(S, 0, P->asString());
             if (z.isBoolean()) {
@@ -596,8 +596,9 @@ static Value builtinStringSplit(ExecutionState& state, Value thisValue, size_t a
 
     size_t q = p;
 
-    if (P->isRegExpObject()) {
-        RegExpObject* R = P->asRegExpObject();
+    // 13
+    if (P->isRegExpObject(state) == true) {
+        RegExpObject* R = P->asRegExpObject(state);
         while (q != s) {
             RegexMatchResult result;
             bool ret = R->matchNonGlobally(state, S, result, false, (size_t)q);
@@ -884,7 +885,7 @@ static Value builtinStringStartsWith(ExecutionState& state, Value thisValue, siz
     Value searchString = argv[0];
     // Let isRegExp be ? IsRegExp(searchString).
     // If isRegExp is true, throw a TypeError exception.
-    if (searchString.isObject() && searchString.asObject()->isRegExpObject()) {
+    if (searchString.isObject() == true && searchString.asObject()->isRegExpObject(state) == true) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "can't use RegExp with startsWith");
     }
     // Let searchStr be ? ToString(searchString).
@@ -927,7 +928,7 @@ static Value builtinStringEndsWith(ExecutionState& state, Value thisValue, size_
     Value searchString = argv[0];
     // Let isRegExp be ? IsRegExp(searchString).
     // If isRegExp is true, throw a TypeError exception.
-    if (searchString.isObject() && searchString.asObject()->isRegExpObject()) {
+    if (searchString.isObject() == true && searchString.asObject()->isRegExpObject(state) == true) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "can't use RegExp with endsWith");
     }
     // Let len be the number of elements in S.
@@ -1031,7 +1032,7 @@ static Value builtinStringIncludes(ExecutionState& state, Value thisValue, size_
     // Let isRegExp be ? IsRegExp(searchString).
     // If isRegExp is true, throw a TypeError exception.
     Value searchString = argv[0];
-    if (searchString.isObject() && searchString.asObject()->isRegExpObject()) {
+    if (searchString.isObject() == true && searchString.asObject()->isRegExpObject(state) == true) {
         ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "can't use RegExp with includes");
     }
 

--- a/src/runtime/Object.cpp
+++ b/src/runtime/Object.cpp
@@ -1122,4 +1122,32 @@ Value Object::speciesConstructor(ExecutionState& state, const Value& defaultCons
     ErrorObject::throwBuiltinError(state, ErrorObject::TypeError, "invalid speciesConstructor return");
     return Value();
 }
+
+String* Object::optionString(ExecutionState& state)
+{
+    char flags[6] = { 0 };
+    int flags_idx = 0;
+
+    if (this->get(state, ObjectPropertyName(state, state.context()->staticStrings().global)).value(state, this).toBoolean(state) == true) {
+        flags[flags_idx++] = 'g';
+    }
+
+    if (this->get(state, ObjectPropertyName(state, state.context()->staticStrings().ignoreCase)).value(state, this).toBoolean(state) == true) {
+        flags[flags_idx++] = 'i';
+    }
+
+    if (this->get(state, ObjectPropertyName(state, state.context()->staticStrings().multiline)).value(state, this).toBoolean(state) == true) {
+        flags[flags_idx++] = 'm';
+    }
+
+    if (this->get(state, ObjectPropertyName(state, state.context()->staticStrings().unicode)).value(state, this).toBoolean(state) == true) {
+        flags[flags_idx++] = 'u';
+    }
+
+    if (this->get(state, ObjectPropertyName(state, state.context()->staticStrings().sticky)).value(state, this).toBoolean(state) == true) {
+        flags[flags_idx++] = 'y';
+    }
+
+    return new ASCIIString(flags);
+}
 }

--- a/src/runtime/Object.h
+++ b/src/runtime/Object.h
@@ -550,11 +550,13 @@ public:
         return (ArrayObject*)this;
     }
 
-    RegExpObject* asRegExpObject()
+    RegExpObject* asRegExpObject(ExecutionState& state)
     {
-        ASSERT(isRegExpObject());
+        ASSERT(isRegExpObject(state) == true);
         return (RegExpObject*)this;
     }
+
+    String* optionString(ExecutionState& state);
 
 #if ESCARGOT_ENABLE_TYPEDARRAY
     ArrayBufferObject* asArrayBufferObject()

--- a/src/runtime/PointerValue.h
+++ b/src/runtime/PointerValue.h
@@ -124,7 +124,12 @@ public:
         return false;
     }
 
-    virtual bool isRegExpObject() const
+    virtual bool isRegExpObject(ExecutionState& state)
+    {
+        return false;
+    }
+
+    virtual bool isRegExpPrototypeObject() const
     {
         return false;
     }
@@ -285,9 +290,9 @@ public:
         return (BooleanObject*)this;
     }
 
-    RegExpObject* asRegExpObject()
+    RegExpObject* asRegExpObject(ExecutionState& state)
     {
-        ASSERT(isRegExpObject());
+        ASSERT(isRegExpObject(state) == true);
         return (RegExpObject*)this;
     }
 

--- a/src/runtime/RegExpObject.cpp
+++ b/src/runtime/RegExpObject.cpp
@@ -204,11 +204,14 @@ bool RegExpObject::defineOwnProperty(ExecutionState& state, const ObjectProperty
     return returnValue;
 }
 
+bool RegExpObject::isRegExpObject(ExecutionState& state)
+{
+    return this->getPrototypeObject(state)->isRegExpPrototypeObject() || isRegExpPrototypeObject();
+}
+
 void RegExpObject::parseOption(ExecutionState& state, const String* optionString)
 {
     this->m_option = RegExpObject::Option::None;
-    std::string optionStr;
-    this->m_optionString = String::emptyString;
 
     for (size_t i = 0; i < optionString->length(); i++) {
         switch (optionString->charAt(i)) {
@@ -216,39 +219,31 @@ void RegExpObject::parseOption(ExecutionState& state, const String* optionString
             if (this->m_option & Option::Global)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'g' flags");
             this->m_option = (Option)(this->m_option | Option::Global);
-            optionStr.append("g");
             break;
         case 'i':
             if (this->m_option & Option::IgnoreCase)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'i' flags");
             this->m_option = (Option)(this->m_option | Option::IgnoreCase);
-            optionStr.append("i");
             break;
         case 'm':
             if (this->m_option & Option::MultiLine)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'm' flags");
             this->m_option = (Option)(this->m_option | Option::MultiLine);
-            optionStr.append("m");
             break;
         case 'u':
             if (this->m_option & Option::Unicode)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'u' flags");
             this->m_option = (Option)(this->m_option | Option::Unicode);
-            optionStr.append("u");
             break;
         case 'y':
             if (this->m_option & Option::Sticky)
                 ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has multiple 'y' flags");
             this->m_option = (Option)(this->m_option | Option::Sticky);
-            optionStr.append("y");
             break;
         default:
             ErrorObject::throwBuiltinError(state, ErrorObject::SyntaxError, "RegExp has invalid flag");
         }
     }
-
-    std::sort(optionStr.begin(), optionStr.end());
-    this->m_optionString = String::fromASCII(optionStr.c_str());
 }
 
 void RegExpObject::setOption(const Option& option)

--- a/src/runtime/RegExpObject.h
+++ b/src/runtime/RegExpObject.h
@@ -110,11 +110,6 @@ public:
         return m_source;
     }
 
-    String* optionString()
-    {
-        return m_optionString;
-    }
-
     Option option()
     {
         return m_option;
@@ -138,10 +133,7 @@ public:
     void setLastIndex(ExecutionState& state, const Value& v);
     virtual bool defineOwnProperty(ExecutionState& state, const ObjectPropertyName& P, const ObjectPropertyDescriptor& desc);
 
-    virtual bool isRegExpObject() const
-    {
-        return true;
-    }
+    virtual bool isRegExpObject(ExecutionState& state);
 
     void createRegexMatchResult(ExecutionState& state, String* str, RegexMatchResult& result);
     ArrayObject* createMatchedArray(ExecutionState& state, String* str, RegexMatchResult& result);
@@ -179,6 +171,19 @@ private:
 
     SmallValue m_lastIndex;
     const String* m_lastExecutedString;
+};
+
+class RegExpObjectPrototype : public RegExpObject {
+public:
+    RegExpObjectPrototype(ExecutionState& state)
+        : RegExpObject(state)
+    {
+    }
+
+    virtual bool isRegExpPrototypeObject() const
+    {
+        return true;
+    }
 };
 
 typedef std::unordered_map<RegExpObject::RegExpCacheKey, RegExpObject::RegExpCacheEntry,

--- a/src/runtime/StaticStrings.cpp
+++ b/src/runtime/StaticStrings.cpp
@@ -84,6 +84,15 @@ void StaticStrings::initStaticStrings(AtomicStringMap* atomicStringMap)
     getLength.init(atomicStringMap, "get length", strlen("get length"));
     getBuffer.init(atomicStringMap, "get buffer", strlen("get buffer"));
     getSize.init(atomicStringMap, "get size", strlen("get size"));
+#ifdef ESCARGOT_ENABLE_ES2015
+    getFlags.init(atomicStringMap, "get flags", strlen("get flags"));
+    getGlobal.init(atomicStringMap, "get global", strlen("get global"));
+    getIgnoreCase.init(atomicStringMap, "get ignoreCase", strlen("get ignoreCase"));
+    getMultiline.init(atomicStringMap, "get multiline", strlen("get multiline"));
+    getSource.init(atomicStringMap, "get source", strlen("get source"));
+    getSticky.init(atomicStringMap, "get sticky", strlen("get sticky"));
+    getUnicode.init(atomicStringMap, "get unicode", strlen("get unicode"));
+#endif
     getSymbolSpecies.init(atomicStringMap, "get [Symbol.species]", strlen("get [Symbol.species]"));
     getSymbolSearch.init(atomicStringMap, "get [Symbol.search]", strlen("get [Symbol.search]"));
     getSymbolToStringTag.init(atomicStringMap, "get [Symbol.toStringTag]", strlen("get [Symbol.toStringTag]"));

--- a/src/runtime/StaticStrings.h
+++ b/src/runtime/StaticStrings.h
@@ -451,6 +451,15 @@ public:
     AtomicString getbyteOffset;
     AtomicString getLength;
     AtomicString getBuffer;
+#ifdef ESCARGOT_ENABLE_ES2015
+    AtomicString getFlags;
+    AtomicString getGlobal;
+    AtomicString getIgnoreCase;
+    AtomicString getMultiline;
+    AtomicString getSource;
+    AtomicString getSticky;
+    AtomicString getUnicode;
+#endif
     AtomicString getSize;
     AtomicString getSymbolSpecies;
     AtomicString getSymbolSearch;

--- a/src/runtime/VMInstance.cpp
+++ b/src/runtime/VMInstance.cpp
@@ -30,10 +30,12 @@ extern size_t g_doubleInSmallValueTag;
 extern size_t g_objectRareDataTag;
 extern size_t g_symbolTag;
 
+#ifndef ESCARGOT_ENABLE_ES2015
 bool VMInstance::undefinedNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData)
 {
     return false;
 }
+#endif
 
 Value VMInstance::functionPrototypeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
@@ -103,26 +105,36 @@ bool VMInstance::stringLengthNativeSetter(ExecutionState& state, Object* self, S
 static ObjectPropertyNativeGetterSetterData stringLengthGetterSetterData(
     false, false, false, &VMInstance::stringLengthNativeGetter, &VMInstance::stringLengthNativeSetter);
 
+#ifndef ESCARGOT_ENABLE_ES2015
 Value VMInstance::regexpSourceNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value(self->asRegExpObject()->source());
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+
+    return Value(self->asRegExpObject(state)->source());
 }
+
 static ObjectPropertyNativeGetterSetterData regexpSourceGetterData(
     false, false, false, &VMInstance::regexpSourceNativeGetter, &VMInstance::undefinedNativeSetter);
 
 Value VMInstance::regexpFlagsNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value(self->asRegExpObject()->optionString());
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value(self->asRegExpObject(state)->optionString(state));
 }
+
 static ObjectPropertyNativeGetterSetterData regexpFlagsGetterData(
     false, false, true, &VMInstance::regexpFlagsNativeGetter, &VMInstance::undefinedNativeSetter);
 
 Value VMInstance::regexpGlobalNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::Global));
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value((bool)(self->asRegExpObject(state)->option() & RegExpObject::Option::Global));
 }
 
 static ObjectPropertyNativeGetterSetterData regexpGlobalGetterData(
@@ -130,8 +142,10 @@ static ObjectPropertyNativeGetterSetterData regexpGlobalGetterData(
 
 Value VMInstance::regexpIgnoreCaseNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::IgnoreCase));
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value((bool)(self->asRegExpObject(state)->option() & RegExpObject::Option::IgnoreCase));
 }
 
 static ObjectPropertyNativeGetterSetterData regexpIgnoreCaseGetterData(
@@ -139,8 +153,10 @@ static ObjectPropertyNativeGetterSetterData regexpIgnoreCaseGetterData(
 
 Value VMInstance::regexpMultilineNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::MultiLine));
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value((bool)(self->asRegExpObject(state)->option() & RegExpObject::Option::MultiLine));
 }
 
 static ObjectPropertyNativeGetterSetterData regexpMultilineGetterData(
@@ -148,8 +164,10 @@ static ObjectPropertyNativeGetterSetterData regexpMultilineGetterData(
 
 Value VMInstance::regexpStickyNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::Sticky));
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value((bool)(self->asRegExpObject(state)->option() & RegExpObject::Option::Sticky));
 }
 
 static ObjectPropertyNativeGetterSetterData regexpStickyGetterData(
@@ -157,23 +175,28 @@ static ObjectPropertyNativeGetterSetterData regexpStickyGetterData(
 
 Value VMInstance::regexpUnicodeNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return Value((bool)(self->asRegExpObject()->option() & RegExpObject::Option::Unicode));
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return Value((bool)(self->asRegExpObject(state)->option() & RegExpObject::Option::Unicode));
 }
 
 static ObjectPropertyNativeGetterSetterData regexpUnicodeGetterData(
     false, false, false, &VMInstance::regexpUnicodeNativeGetter, &VMInstance::undefinedNativeSetter);
+#endif
 
 Value VMInstance::regexpLastIndexNativeGetter(ExecutionState& state, Object* self, const SmallValue& privateDataFromObjectPrivateArea)
 {
-    ASSERT(self->isRegExpObject());
-    return self->asRegExpObject()->lastIndex();
+    if (self->isRegExpObject(state) == false) {
+        ErrorObject::throwBuiltinError(state, ErrorObject::Code::TypeError, "getter called on non-RegExp object");
+    }
+    return self->asRegExpObject(state)->lastIndex();
 }
 
 bool VMInstance::regexpLastIndexNativeSetter(ExecutionState& state, Object* self, SmallValue& privateDataFromObjectPrivateArea, const Value& setterInputData)
 {
-    ASSERT(self->isRegExpObject());
-    self->asRegExpObject()->setLastIndex(state, setterInputData);
+    ASSERT(self->isRegExpObject(state) == true);
+    self->asRegExpObject(state)->setLastIndex(state, setterInputData);
     return true;
 }
 
@@ -306,7 +329,7 @@ VMInstance::VMInstance(const char* locale, const char* timezone)
 
     m_defaultStructureForRegExpObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.lastIndex,
                                                                                  ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpLastIndexGetterSetterData));
-    // TODO(ES6): Below RegExp data properties is changed to accessor properties of RegExp.prototype in ES6.
+#ifndef ESCARGOT_ENABLE_ES2015
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.source,
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpSourceGetterData));
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.flags,
@@ -321,6 +344,7 @@ VMInstance::VMInstance(const char* locale, const char* timezone)
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpStickyGetterData));
     m_defaultStructureForRegExpObject = m_defaultStructureForRegExpObject->addProperty(stateForInit, m_staticStrings.unicode,
                                                                                        ObjectStructurePropertyDescriptor::createDataButHasNativeGetterSetterDescriptor(&regexpUnicodeGetterData));
+#endif
 
     m_defaultStructureForArgumentsObject = m_defaultStructureForObject->addProperty(stateForInit, m_staticStrings.length, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));
     m_defaultStructureForArgumentsObject = m_defaultStructureForArgumentsObject->addProperty(stateForInit, m_staticStrings.callee, ObjectStructurePropertyDescriptor::createDataDescriptor((ObjectStructurePropertyDescriptor::PresentAttribute)(ObjectStructurePropertyDescriptor::WritablePresent | ObjectStructurePropertyDescriptor::ConfigurablePresent)));

--- a/test/es2015/13.delete.js
+++ b/test/es2015/13.delete.js
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var scenarios = [
+ ["obj.foo", false],       // obj is configurable false
+ ["'hello'[0]", false],
+ ["'hello'.length", false],
+ ["reg.source", true],
+ ["reg.global", true],
+ ["reg.lastIndex", false],
+];
+
+(function Test1(x) {
+    var str = "delete configurable false property";
+
+    var obj = new Object();
+    Object.defineProperty(obj, "foo", { configurable: false, value: 20 });
+
+    var reg = /foo/;
+
+    for (var i = 0; i < scenarios.length; ++i) {
+        var r = eval("delete " + scenarios[i][0]);
+        assert(scenarios[i][1] === r);
+    }
+})();

--- a/test/es2015/prototypeInheritance2.js
+++ b/test/es2015/prototypeInheritance2.js
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+/* ES6 compatible test */
+
+print("Test 1: Math.E");
+var obj = Object.create(Math);
+obj.E = "foo";
+assert(obj.E === 2.718281828459045);
+
+print("Test 2: function length");
+function myFunc(a, b, c, d) {}
+obj = Object.create(myFunc);
+obj.length = "foo";
+assert(obj.length === 4);
+
+print("Test 3: Regular expression properties");
+var regExp = new RegExp("/abc/g");
+obj = Object.create(regExp);
+obj.global = "foo";
+try {
+  obj.global;
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+obj.lastIndex = "foo";
+print(obj.lastIndex === "foo");
+
+print("Test 4: String length");
+obj = Object.create(new String("test"));
+obj.length = "foo";
+assert(obj.length === 4);

--- a/test/regression-tests/issue-130.js
+++ b/test/regression-tests/issue-130.js
@@ -1,12 +1,15 @@
 var r = / /;
 
-var failures = ['global', 'ignoreCase', 'multiline', 'source'];
+var properties = ['global', 'ignoreCase', 'multiline', 'source'];
 
-failures.forEach(function(prop) {
+properties.forEach(function(prop) {
   try {
+    Object.defineProperty(r, prop, {value: true});
+    assert(r[prop]);
     Object.defineProperty(r, prop, {value: false});
     assert(false);
   } catch(e) {
+    assert(r[prop]);
     assert(e instanceof TypeError);
   }
 });


### PR DESCRIPTION
Fixes `regexp-flags.js` testcase in v8.

Co-authored-by: Robert Fancsik <frobert@inf.u-szeged.hu>
Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>