### PR TITLE
Merge IteratorStep and IteratorValue bytecodes

### DIFF
--- a/src/interpreter/ByteCode.h
+++ b/src/interpreter/ByteCode.h
@@ -112,7 +112,6 @@ class Node;
     F(CheckIfKeyIsLast, 0, 0)                         \
     F(GetIterator, 1, 0)                              \
     F(IteratorStep, 1, 0)                             \
-    F(IteratorValue, 1, 0)                            \
     F(LoadRegexp, 1, 0)                               \
     F(WithOperation, 0, 0)                            \
     F(ObjectDefineGetter, 0, 0)                       \
@@ -1763,6 +1762,14 @@ public:
         m_forOfEndPosition = SIZE_MAX;
         m_registerIndex = m_iterRegisterIndex = REGISTER_LIMIT;
     }
+
+    explicit IteratorStep(const ByteCodeLOC& loc, size_t dstIndex, size_t iterIndex)
+        : ByteCode(Opcode::IteratorStepOpcode, loc)
+        , m_registerIndex(dstIndex)
+        , m_iterRegisterIndex(iterIndex)
+        , m_forOfEndPosition(SIZE_MAX)
+    {
+    }
     ByteCodeRegisterIndex m_registerIndex;
     ByteCodeRegisterIndex m_iterRegisterIndex;
     size_t m_forOfEndPosition;
@@ -1771,25 +1778,6 @@ public:
     void dump(const char* byteCodeStart)
     {
         printf("iterator step(r%d) -> r%d", (int)m_iterRegisterIndex, (int)m_registerIndex);
-    }
-#endif
-};
-
-class IteratorValue : public ByteCode {
-public:
-    IteratorValue(const ByteCodeLOC& loc, size_t iterIndex, size_t dstIndex)
-        : ByteCode(Opcode::IteratorValueOpcode, loc)
-        , m_iterIndex(iterIndex)
-        , m_dstIndex(dstIndex)
-    {
-    }
-
-    ByteCodeRegisterIndex m_iterIndex;
-    ByteCodeRegisterIndex m_dstIndex;
-#ifndef NDEBUG
-    void dump(const char* byteCodeStart)
-    {
-        printf("iterator value (r%d) -> r%d", (int)m_iterIndex, (int)m_dstIndex);
     }
 #endif
 };

--- a/src/interpreter/ByteCodeGenerator.cpp
+++ b/src/interpreter/ByteCodeGenerator.cpp
@@ -512,9 +512,9 @@ ByteCodeBlock* ByteCodeGenerator::generateByteCode(Context* c, InterpretedCodeBl
                 assignStackIndexIfNeeded(cd->m_objectRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
-            case IteratorValueOpcode: {
-                IteratorValue* cd = (IteratorValue*)currentCode;
-                assignStackIndexIfNeeded(cd->m_iterIndex, stackBase, stackBaseWillBe, stackVariableSize);
+            case IteratorStepOpcode: {
+                IteratorStep* cd = (IteratorStep*)currentCode;
+                assignStackIndexIfNeeded(cd->m_iterRegisterIndex, stackBase, stackBaseWillBe, stackVariableSize);
                 break;
             }
             case BindingRestElementOpcode: {

--- a/src/parser/ast/ArrayPatternNode.h
+++ b/src/parser/ast/ArrayPatternNode.h
@@ -95,7 +95,7 @@ public:
             RefPtr<Node> element = m_elements[i];
 
             size_t iteratorValueIdx = context->getRegister();
-            codeBlock->pushCode(IteratorValue(ByteCodeLOC(m_loc.index), iteratorIdx, iteratorValueIdx), context, this);
+            codeBlock->pushCode(IteratorStep(ByteCodeLOC(m_loc.index), iteratorValueIdx, iteratorIdx), context, this);
 
             if (element != nullptr) {
                 if (element->isPattern()) {


### PR DESCRIPTION
* IteratorValue can be replaced with IteratorStep
* it's better to keep the number of bytecode as small as possible

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>