### PR TITLE
Change m_controlFlowRecord vector into a size_t counter.

### DIFF
--- a/src/runtime/ExecutionState.cpp
+++ b/src/runtime/ExecutionState.cpp
@@ -31,7 +31,7 @@ void ExecutionState::throwException(const Value& e)
 
 ExecutionState* ExecutionState::parent()
 {
-    if (m_parent & 1) {
+    if (hasRareData() == false) {
         return (ExecutionState*)(m_parent - 1);
     } else {
         return rareData()->m_parent;
@@ -40,7 +40,7 @@ ExecutionState* ExecutionState::parent()
 
 ExecutionStateRareData* ExecutionState::ensureRareData()
 {
-    if (m_parent & 1) {
+    if (hasRareData() == false) {
         ExecutionState* p = parent();
         m_rareData = new ExecutionStateRareData();
         m_rareData->m_parent = p;

--- a/src/runtime/ExecutionState.h
+++ b/src/runtime/ExecutionState.h
@@ -32,11 +32,13 @@ class ControlFlowRecord;
 typedef Vector<ControlFlowRecord*, GCUtil::gc_malloc_ignore_off_page_allocator<ControlFlowRecord*>> ControlFlowRecordVector;
 
 struct ExecutionStateRareData : public gc {
-    Vector<ControlFlowRecord*, GCUtil::gc_malloc_ignore_off_page_allocator<ControlFlowRecord*>>* m_controlFlowRecord;
+    size_t m_controlFlowDepth;
+    ControlFlowRecord* m_currentControlFlowRecord;
     ExecutionState* m_parent;
     ExecutionStateRareData()
     {
-        m_controlFlowRecord = nullptr;
+        m_controlFlowDepth = 0;
+        m_currentControlFlowRecord = nullptr;
         m_parent = nullptr;
     }
 };
@@ -112,8 +114,14 @@ public:
     ExecutionState* parent();
     ExecutionStateRareData* ensureRareData();
 
+    bool hasRareData()
+    {
+        return (m_parent & 1) == 0;
+    }
+
     ExecutionStateRareData* rareData()
     {
+        ASSERT(hasRareData());
         return m_rareData;
     }
 


### PR DESCRIPTION
Vector operations are costly, and this vector contains only nullptr values except the last one.